### PR TITLE
Draw all Graph text (and shapes) onto one Canvas

### DIFF
--- a/dependencies/maven/artifacts.bzl
+++ b/dependencies/maven/artifacts.bzl
@@ -35,6 +35,7 @@ artifacts = [
     "org.jetbrains.kotlin:kotlin-test",
     "org.jetbrains.kotlinx:kotlinx-coroutines-core",
     "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
+    "org.jetbrains.skiko:skiko-awt",
     "org.jetbrains.skiko:skiko-awt-runtime-linux-x64",
     "org.jetbrains.skiko:skiko-awt-runtime-macos-x64",
     "org.jetbrains.skiko:skiko-awt-runtime-windows-x64",

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -18,14 +18,10 @@
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 def vaticle_dependencies():
-#    git_repository(
-#        name = "vaticle_dependencies",
-#        remote = "https://github.com/vaticle/dependencies",
-#        commit = "465e60776ca3055ce85d90e94624d37db3f7e790", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
-#    )
-    native.local_repository(
+    git_repository(
         name = "vaticle_dependencies",
-        path = "../dependencies",
+        remote = "https://github.com/vaticle/dependencies",
+        commit = "4a544ebff1fa4d87e34ae6f14d11c2789c5a3740", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_force_graph():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -18,10 +18,14 @@
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 def vaticle_dependencies():
-    git_repository(
+#    git_repository(
+#        name = "vaticle_dependencies",
+#        remote = "https://github.com/vaticle/dependencies",
+#        commit = "465e60776ca3055ce85d90e94624d37db3f7e790", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+#    )
+    native.local_repository(
         name = "vaticle_dependencies",
-        remote = "https://github.com/vaticle/dependencies",
-        commit = "465e60776ca3055ce85d90e94624d37db3f7e790", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        path = "../dependencies",
     )
 
 def vaticle_force_graph():

--- a/view/common/BUILD
+++ b/view/common/BUILD
@@ -37,6 +37,7 @@ kt_jvm_library(
         "@maven//:org_jetbrains_compose_ui_ui_graphics_desktop",
         "@maven//:org_jetbrains_compose_ui_ui_text_desktop",
         "@maven//:org_jetbrains_compose_ui_ui_unit_desktop",
+        "@maven//:org_jetbrains_skiko_skiko_awt",
         "@maven//:org_slf4j_slf4j_api",
     ],
     resources = [

--- a/view/common/theme/Typography.kt
+++ b/view/common/theme/Typography.kt
@@ -23,10 +23,15 @@ import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontListFontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.font.ResourceFont
 import androidx.compose.ui.text.platform.Font
 import androidx.compose.ui.unit.sp
+import org.jetbrains.skia.Data
+import org.jetbrains.skia.Typeface
+import org.jetbrains.skia.makeFromFileName
 
 object Typography {
 
@@ -58,7 +63,8 @@ object Typography {
     @Stable
     class Theme constructor(
         variableWidthFontFamily: FontFamily, fixedWidthFontFamily: FontFamily,
-        bodySizeMedium: Int, bodySizeSmall: Int, codeSizeMedium: Int, codeSizeSmall: Int
+        val fixedWidthSkiaTypeface: Typeface,
+        bodySizeMedium: Int, bodySizeSmall: Int, val codeSizeMedium: Int, codeSizeSmall: Int,
     ) {
         val body1 = TextStyle(fontSize = bodySizeMedium.sp, fontFamily = variableWidthFontFamily)
         val body2 = TextStyle(fontSize = bodySizeSmall.sp, fontFamily = variableWidthFontFamily)
@@ -72,11 +78,17 @@ object Typography {
         Font(TITILLIUM_WEB_REGULAR, FontWeight.Normal, FontStyle.Normal),
         Font(TITILLIUM_WEB_SEMI_BOLD, FontWeight.SemiBold, FontStyle.Normal)
     )
+    private val UBUNTU_MONO_SKIA_TYPEFACE = Typeface.makeFromData(
+        Data.makeFromBytes(
+            ClassLoader.getSystemClassLoader().getResourceAsStream(UBUNTU_MONO_REGULAR)!!.use { it.readAllBytes() }
+        )
+    )
 
     object Themes {
         val DEFAULT = Theme(
             variableWidthFontFamily = TITILLIUM_WEB_FAMILY,
             fixedWidthFontFamily = UBUNTU_MONO_FAMILY,
+            fixedWidthSkiaTypeface = UBUNTU_MONO_SKIA_TYPEFACE,
             bodySizeMedium = DEFAULT_BODY_FONT_SIZE_MEDIUM,
             bodySizeSmall = DEFAULT_BODY_FONT_SIZE_SMALL,
             codeSizeMedium = DEFAULT_CODE_FONT_SIZE_MEDIUM,

--- a/view/graph/BUILD
+++ b/view/graph/BUILD
@@ -53,6 +53,7 @@ kt_jvm_library(
         "@maven//:org_jetbrains_compose_ui_ui_text_desktop",
         "@maven//:org_jetbrains_compose_ui_ui_unit_desktop",
         "@maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core_jvm",
+        "@maven//:org_jetbrains_skiko_skiko_awt",
         "@maven//:org_slf4j_slf4j_api",
     ],
     tags = ["maven_coordinates=com.vaticle.typedb:typedb-studio-view-graph:{pom_version}"],

--- a/view/graph/EdgeRenderer.kt
+++ b/view/graph/EdgeRenderer.kt
@@ -21,12 +21,17 @@ package com.vaticle.typedb.studio.view.graph
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Paint
 import androidx.compose.ui.graphics.PointMode
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.graphics.nativeCanvas
 import com.vaticle.typedb.studio.view.common.geometry.Geometry
 import com.vaticle.typedb.studio.view.common.geometry.Geometry.normalisedAngle
 import com.vaticle.typedb.studio.view.common.geometry.Geometry.radToDeg
 import com.vaticle.typedb.studio.view.common.theme.Color
+import org.jetbrains.skia.Font
+import org.jetbrains.skia.TextLine
 import kotlin.math.abs
 import kotlin.math.atan2
 
@@ -39,6 +44,7 @@ class EdgeRenderer(private val graphArea: GraphArea, private val ctx: RendererCo
     }
 
     private val viewport = graphArea.viewport
+    private val interactions = graphArea.interactions
     val density = graphArea.viewport.density
     private val edgeLabelSizes = graphArea.edgeLabelSizes
 
@@ -53,6 +59,7 @@ class EdgeRenderer(private val graphArea: GraphArea, private val ctx: RendererCo
             val (curvedEdges, straightEdges) = edges.partition { it.geometry.isCurved }
             drawLines(straightEdges, true, color)
             curvedEdges.forEach { drawCurvedEdge(it, color) }
+            edges.forEach { drawLabel(it) }
         } else {
             drawLines(edges, false, color)
         }
@@ -196,6 +203,23 @@ class EdgeRenderer(private val graphArea: GraphArea, private val ctx: RendererCo
             Rect(
                 Offset(position.x - it.width.value / 2 - 2, position.y - it.height.value / 2 - 2),
                 Size(it.width.value + 4, it.height.value + 4)
+            )
+        }
+    }
+
+    private fun drawLabel(edge: Edge) {
+        val center = with(viewport) { (edge.geometry.curveMidpoint ?: edge.geometry.midpoint).toViewport() }
+        val baseColor = if (edge is Edge.Inferrable && edge.isInferred) ctx.theme.inferred else ctx.theme.edgeLabel
+        val alpha = with(interactions) { if (edge.isBackground) BACKGROUND_ALPHA else 1f }
+        val textLine = TextLine.make(
+            edge.label, Font(ctx.typography.fixedWidthSkiaTypeface, ctx.typography.codeSizeMedium * density)
+        )
+        ctx.drawScope.drawIntoCanvas {
+            it.nativeCanvas.drawTextLine(
+                textLine,
+                center.x - textLine.width / 2,
+                center.y + textLine.capHeight / 2,
+                Paint().apply { color = baseColor.copy(alpha) }.asFrameworkPaint()
             )
         }
     }

--- a/view/graph/Graph.kt
+++ b/view/graph/Graph.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import com.vaticle.force.graph.api.Simulation
 import com.vaticle.force.graph.force.CenterForce
 import com.vaticle.force.graph.force.CollideForce
@@ -34,9 +35,12 @@ import com.vaticle.force.graph.impl.BasicVertex
 import com.vaticle.force.graph.util.RandomEffects
 import com.vaticle.typedb.client.api.answer.ConceptMap
 import com.vaticle.typedb.client.api.logic.Explanation
+import com.vaticle.typedb.studio.view.common.theme.Typography
 import com.vaticle.typedb.studio.view.graph.Graph.Physics.Constants.COLLIDE_RADIUS
 import com.vaticle.typedb.studio.view.graph.Graph.Physics.Constants.CURVE_COLLIDE_RADIUS
 import com.vaticle.typedb.studio.view.graph.Graph.Physics.Constants.CURVE_COMPRESSION_POWER
+import org.jetbrains.skia.Font
+import org.jetbrains.skia.TextLine
 import java.util.Collections
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
@@ -55,6 +59,33 @@ class Graph(private val interactions: Interactions) {
 
     val physics = Physics(this, interactions)
     val reasoning = Reasoning()
+
+//    private var _textRendering: TextRendering? = null
+//
+//    class TextRendering(val typography: Typography.Theme, val density: Float, val font: Font) {
+//        private val _map = ConcurrentHashMap<String, Value>()
+//
+//        operator fun get(key: String) = _map[key]
+//
+//        // TODO: support multiline text
+//        fun compute(key: String) {
+//            _map.computeIfAbsent(key) { TextLine.make(key, font).let { Value(it, Size(it.width, it.capHeight)) } }
+//        }
+//
+//        fun isUpToDate(currentTypography: Typography.Theme, currentDensity: Float): Boolean {
+//            return typography == currentTypography && density == currentDensity
+//        }
+//
+//        data class Value(val textLine: TextLine, val size: Size)
+//    }
+//
+//    // TODO: this will wipe out the rendering data when changing screens
+//    fun getTextRendering(typography: Typography.Theme, density: Float): TextRendering {
+//        val current = _textRendering
+//        if (current?.isUpToDate(typography, density) == true) return current
+//        val font = Font(typeface = typography.fixedWidthSkiaTypeface, size = typography.codeSizeMedium * density)
+//        return TextRendering(typography, density, font).also { _textRendering = it }
+//    }
 
     fun putThingVertex(iid: String, vertex: Vertex.Thing) {
         putVertex(iid, _thingVertices, vertex)

--- a/view/graph/RendererContext.kt
+++ b/view/graph/RendererContext.kt
@@ -20,5 +20,6 @@ package com.vaticle.typedb.studio.view.graph
 
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import com.vaticle.typedb.studio.view.common.theme.Color
+import com.vaticle.typedb.studio.view.common.theme.Typography
 
-data class RendererContext(val drawScope: DrawScope, val theme: Color.GraphTheme)
+data class RendererContext(val drawScope: DrawScope, val theme: Color.GraphTheme, val typography: Typography.Theme)


### PR DESCRIPTION
## What is the goal of this PR?

Previously, text was rendered in a separate "layer" to shapes, meaning that to render the graph we needed 2 Canvases and 2 other "layers". We've significantly cleaned up the `GraphArea` implementation, by now drawing all Graph text (and shapes) onto a single Canvas. As a result, this has eliminated "jitter" where shapes and their labels would frequently go out of sync.

## What are the changes implemented in this PR?

The reason we originally used these separate layers is because `DrawScope`, the object provided to us while drawing inside a `Canvas`, does NOT provide a `drawText` method. However, we've now discovered that by depending on the underlying Skia library `skiko-awt`, we can call `drawIntoCanvas { it.nativeCanvas.drawTextLine() }`, which _does_ draw text onto a Canvas, and is both more consistent than the previous approach (it completely eliminates jitter), and more performant (we're bypassing all the hoops that Compose Material goes through when drawing Material Text).

Nonetheless, we would like to not have to interface with Skia directly if at all possible. The ability to draw text in a `DrawScope` has been a much-requested feature in the Jetpack Compose community since mid-2021, but it hasn't materialised yet. So for now, we will use Skia's own methods, which are quite low-level.