### PR TITLE
Fix possible error when drawing an attribute's edge

### DIFF
--- a/view/common/geometry/Geometry.kt
+++ b/view/common/geometry/Geometry.kt
@@ -311,7 +311,7 @@ object Geometry {
     /**
      * Find intersection point of a line from `sourcePoint` through the centre of `ellipse`, with the edge of `ellipse`
      */
-    fun ellipseIncomingLineIntersect(sourcePoint: Offset, ellipse: Ellipse): Offset {
+    fun ellipseIncomingLineIntersect(sourcePoint: Offset, ellipse: Ellipse): Offset? {
         var px = sourcePoint.x; var py = sourcePoint.y
         val x = ellipse.x; val y = ellipse.y
         val a = ellipse.hw; val b = ellipse.hh // ellipse has centre (x,y) and semiaxes of lengths [a,b]
@@ -320,9 +320,13 @@ object Geometry {
         px -= x
         py -= y
 
+        val denominator = sqrt(a*a * py*py + b*b * px*px)
+        if (denominator == 0F) return null
+
         // compute intersection points: +-(x0, y0)
-        val x0 = (a * b * px) / sqrt(a*a * py*py + b*b * px*px)
-        val y0 = (a * b * py) / sqrt(a*a * py*py + b*b * px*px)
+        val x0 = (a * b * px) / denominator
+        val y0 = (a * b * py) / denominator
+
 
         return Offset(x0+x, y0+y)
     }

--- a/view/graph/Vertex.kt
+++ b/view/graph/Vertex.kt
@@ -234,7 +234,7 @@ sealed class Vertex(val concept: Concept, protected val graph: Graph) {
                 return xi + yi < 1f
             }
 
-            override fun edgeEndpoint(source: Offset): Offset {
+            override fun edgeEndpoint(source: Offset): Offset? {
                 val ellipse = Ellipse(position.x, position.y, size.width / 2 + 2, size.height / 2 + 2)
                 return ellipseIncomingLineIntersect(source, ellipse)
             }


### PR DESCRIPTION
## What is the goal of this PR?

We bring the function for finding an attribute's edge endpoint in line with relation and entity's functions by allowing the offset to be nullable.

The user should see fewer crashes in the unlikely case that their schema causes the graph rendering logic to attempt to divide by zero.

## What are the changes implemented in this PR?

We change the function signature of `ellipseIncomingLineIntersect` and `edgeEndpoint` to allow `Offset` to be nullable and detect this case in the body of `ellipseIncomingLineIntersect`.