### PR TITLE
Extend license checkstyle tests and update licenses

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -28,7 +28,7 @@ build:
       command: |
         bazel build //...
         bazel run @vaticle_dependencies//tool/checkstyle:test-coverage
-        bazel test $(bazel query 'kind(checkstyle_test, //...)') --test_output=streamed
+        bazel test $(bazel query 'kind(kt_jvm_test, attr(generator_function, checkstyle_test, //...))') --test_output=streamed
     test:
       image: vaticle-ubuntu-20.04
       command: |

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -28,7 +28,7 @@ build:
       command: |
         bazel build //...
         bazel run @vaticle_dependencies//tool/checkstyle:test-coverage
-        bazel test $(bazel query 'kind(kt_jvm_test, attr(generator_function, checkstyle_test, //...))') --test_output=streamed
+        bazel test $(bazel query 'kind(checkstyle_test, //...)') --test_output=streamed
     test:
       image: vaticle-ubuntu-20.04
       command: |

--- a/BUILD
+++ b/BUILD
@@ -185,9 +185,26 @@ deploy_brew(
 
 checkstyle_test(
     name = "checkstyle",
-    include = glob(["*", ".grabl/*", ".circleci/**"]),
-    exclude = glob(["docs/*", ".circleci/windows/*"]),
-    license_type = "agpl",
+    include = glob([
+        "*",
+        ".grabl/*",
+        ".circleci/**",
+    ]),
+    exclude = glob([
+        "*.md",
+        ".bazelversion",
+        ".circleci/windows/*",
+        "LICENSE",
+        "VERSION",
+        "docs/*",
+    ]),
+    license_type = "agpl-header",
+)
+
+checkstyle_test(
+    name = "checkstyle-license",
+    include = ["LICENSE"],
+    license_type = "agpl-fulltext",
 )
 
 # CI targets that are not declared in any BUILD file, but are called externally

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
                     GNU AFFERO GENERAL PUBLIC LICENSE
                        Version 3, 19 November 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -617,45 +617,3 @@ Program, unless a warranty or assumption of liability accompanies a
 copy of the Program in return for a fee.
 
                      END OF TERMS AND CONDITIONS
-
-            How to Apply These Terms to Your New Programs
-
-  If you develop a new program, and you want it to be of the greatest
-possible use to the public, the best way to achieve this is to make it
-free software which everyone can redistribute and change under these terms.
-
-  To do so, attach the following notices to the program.  It is safest
-to attach them to the start of each source file to most effectively
-state the exclusion of warranty; and each file should have at least
-the "copyright" line and a pointer to where the full notice is found.
-
-    <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) <year>  <name of author>
-
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-Also add information on how to contact you by electronic and paper mail.
-
-  If your software can interact with users remotely through a computer
-network, you should also make sure that it provides a way for users to
-get its source.  For example, if your program is a web application, its
-interface could display a "Source" link that leads users to an archive
-of the code.  There are many ways you could offer source, and different
-solutions will be better for different programs; see section 13 for the
-specific requirements.
-
-  You should also get your employer (if you work as a programmer) or school,
-if any, to sign a "copyright disclaimer" for the program, if necessary.
-For more information on this, and how to apply and follow the GNU AGPL, see
-<http://www.gnu.org/licenses/>.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -48,7 +48,7 @@ load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kotlin_repositories", "kt_reg
 kotlin_repositories()
 kt_register_toolchains()
 
-# Load //builder/antlr (required by typedb_client_java > typeql_lang_java)
+# Load //builder/antlr (required by typedb_client_java > typeql)
 load("@vaticle_dependencies//builder/antlr:deps.bzl", antlr_deps = "deps", "antlr_version")
 antlr_deps()
 
@@ -118,17 +118,14 @@ vaticle_typedb_client_java()
 
 load(
     "@vaticle_typedb_client_java//dependencies/vaticle:repositories.bzl",
-    "vaticle_factory_tracing", "vaticle_typedb_protocol", "vaticle_typeql_lang_java"
+    "vaticle_factory_tracing", "vaticle_typedb_protocol", "vaticle_typeql"
 )
-vaticle_typeql_lang_java()
+vaticle_typeql()
 vaticle_factory_tracing()
 vaticle_typedb_protocol()
 
-load("@vaticle_typeql_lang_java//dependencies/vaticle:repositories.bzl", "vaticle_typeql")
-vaticle_typeql()
-
 # Load Maven
-load("@vaticle_typeql_lang_java//dependencies/maven:artifacts.bzl", vaticle_typeql_lang_java_artifacts = "artifacts")
+load("@vaticle_typeql//dependencies/maven:artifacts.bzl", vaticle_typeql_artifacts = "artifacts")
 load("@vaticle_typedb_client_java//dependencies/maven:artifacts.bzl", vaticle_typedb_client_java_artifacts = "artifacts")
 load("@vaticle_typedb_common//dependencies/maven:artifacts.bzl", vaticle_typedb_common_artifacts = "artifacts")
 load("@vaticle_factory_tracing//dependencies/maven:artifacts.bzl", vaticle_factory_tracing_artifacts = "artifacts")
@@ -140,7 +137,7 @@ load("@vaticle_force_graph//dependencies/maven:artifacts.bzl", vaticle_force_gra
 ############################
 maven(
     vaticle_dependencies_tool_maven_artifacts +
-    vaticle_typeql_lang_java_artifacts +
+    vaticle_typeql_artifacts +
     vaticle_typedb_client_java_artifacts +
     vaticle_typedb_common_artifacts +
     vaticle_factory_tracing_artifacts +

--- a/binary/BUILD
+++ b/binary/BUILD
@@ -37,5 +37,5 @@ assemble_targz(
 checkstyle_test(
     name = "checkstyle",
     include = glob(["*"]),
-    license_type = "agpl",
+    license_type = "agpl-header",
 )

--- a/config/brew/BUILD
+++ b/config/brew/BUILD
@@ -24,5 +24,5 @@ exports_files(["typedb-studio.rb"])
 checkstyle_test(
     name = "checkstyle",
     include = glob(["*"]),
-    license_type = "agpl",
+    license_type = "agpl-header",
 )

--- a/config/logback/BUILD
+++ b/config/logback/BUILD
@@ -32,5 +32,5 @@ filegroup(
 checkstyle_test(
     name = "checkstyle",
     include = glob(["*"]),
-    license_type = "agpl",
+    license_type = "agpl-header",
 )

--- a/config/mac/BUILD
+++ b/config/mac/BUILD
@@ -27,5 +27,5 @@ filegroup(
 checkstyle_test(
     name = "checkstyle",
     include = glob(["*"]),
-    license_type = "agpl",
+    license_type = "agpl-header",
 )

--- a/dependencies/maven/BUILD
+++ b/dependencies/maven/BUILD
@@ -23,5 +23,5 @@ checkstyle_test(
     name = "checkstyle",
     include = glob(["*"]),
     exclude = ["artifacts.snapshot"],
-    license_type = "agpl",
+    license_type = "agpl-header",
 )

--- a/dependencies/vaticle/BUILD
+++ b/dependencies/vaticle/BUILD
@@ -22,5 +22,5 @@ package(default_visibility = ["//:__pkg__"])
 checkstyle_test(
     name = "checkstyle",
     include = glob(["*"]),
-    license_type = "agpl",
+    license_type = "agpl-header",
 )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,7 +21,7 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "6904ecb83c744097ef993f29f9941d55538ab331", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "ecadc48b881b373f055c981505a58a02c2decb9b", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_force_graph():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,26 +21,26 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "ecadc48b881b373f055c981505a58a02c2decb9b", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "a8b3b714a5e0562d41f4c05ca8f266d48b7d0fd3", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_force_graph():
     git_repository(
         name = "vaticle_force_graph",
         remote = "https://github.com/vaticle/force-graph",
-        commit = "cdb498b928fb8e18cbd45c3955582a61a9a89dad",
+        commit = "26b760737078afa08976aecd702ea451df049ced",
     )
 
 def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
         remote = "https://github.com/vaticle/typedb-common",
-        commit = "77d07410401435e8274e82c07b73437469e290fe" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        commit = "f0dd708adaea9fe1fdc3699180797a12166d33e8" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_client_java():
     git_repository(
         name = "vaticle_typedb_client_java",
         remote = "https://github.com/vaticle/client-java",
-        commit = "9ed76321aa717bff76f7e5575d1975b02275119b",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_client_java
+        commit = "5717b9cb0c63e0e1c4457ad8e5ad5141d3f04556",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_client_java
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,26 +21,26 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "57617a9978129f5d6b50f69146caaa9e86c3c85e", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "6904ecb83c744097ef993f29f9941d55538ab331", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_force_graph():
     git_repository(
         name = "vaticle_force_graph",
         remote = "https://github.com/vaticle/force-graph",
-        commit = "3b405f9e5b052e921c97939276fe1c95cc8c01ea",
+        commit = "cdb498b928fb8e18cbd45c3955582a61a9a89dad",
     )
 
 def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
         remote = "https://github.com/vaticle/typedb-common",
-        tag = "2.9.0" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        commit = "77d07410401435e8274e82c07b73437469e290fe" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_client_java():
     git_repository(
         name = "vaticle_typedb_client_java",
         remote = "https://github.com/vaticle/client-java",
-        commit = "782eae004922abfc76487c44e70e32d8000f2e9c",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_client_java
+        commit = "9ed76321aa717bff76f7e5575d1975b02275119b",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_client_java
     )

--- a/framework/common/BUILD
+++ b/framework/common/BUILD
@@ -71,5 +71,5 @@ kt_jvm_test(
 checkstyle_test(
     name = "checkstyle",
     include = glob(["*", "*/*"]),
-    license_type = "agpl",
+    license_type = "agpl-header",
 )

--- a/framework/editor/BUILD
+++ b/framework/editor/BUILD
@@ -61,5 +61,5 @@ kt_jvm_library(
 checkstyle_test(
     name = "checkstyle",
     include = glob(["*"]),
-    license_type = "agpl",
+    license_type = "agpl-header",
 )

--- a/framework/editor/highlighter/BUILD
+++ b/framework/editor/highlighter/BUILD
@@ -45,5 +45,5 @@ kt_jvm_library(
 checkstyle_test(
     name = "checkstyle",
     include = glob(["*"]),
-    license_type = "agpl",
+    license_type = "agpl-header",
 )

--- a/framework/editor/highlighter/common/BUILD
+++ b/framework/editor/highlighter/common/BUILD
@@ -46,5 +46,5 @@ kt_jvm_library(
 checkstyle_test(
     name = "checkstyle",
     include = glob(["*"]),
-    license_type = "agpl",
+    license_type = "agpl-header",
 )

--- a/framework/editor/highlighter/typeql/BUILD
+++ b/framework/editor/highlighter/typeql/BUILD
@@ -30,7 +30,7 @@ kt_jvm_library(
         # External Vaticle Dependencies
         "@vaticle_typedb_common//:common",
         "@vaticle_typeql//grammar/java:typeql-grammar",
-        "@vaticle_typeql_lang_java//:typeql-lang",
+        "@vaticle_typeql//java:typeql-lang",
 
         # External Maven Dependencies
         "@maven//:io_github_microutils_kotlin_logging_jvm",

--- a/framework/editor/highlighter/typeql/BUILD
+++ b/framework/editor/highlighter/typeql/BUILD
@@ -45,5 +45,5 @@ kt_jvm_library(
 checkstyle_test(
     name = "checkstyle",
     include = glob(["*"]),
-    license_type = "agpl",
+    license_type = "agpl-header",
 )

--- a/framework/graph/BUILD
+++ b/framework/graph/BUILD
@@ -40,9 +40,9 @@ kt_jvm_library(
         "@vaticle_typedb_common//:common",
         "@vaticle_typedb_client_java//api:api",
         "@vaticle_typedb_client_java//common:common",
-        "@vaticle_typeql_lang_java//:typeql-lang",
-        "@vaticle_typeql_lang_java//pattern:pattern",
-        "@vaticle_typeql_lang_java//query:query",
+        "@vaticle_typeql//java:typeql-lang",
+        "@vaticle_typeql//java/pattern:pattern",
+        "@vaticle_typeql//java/query:query",
 
         # External Maven Dependencies
         "@maven//:io_github_microutils_kotlin_logging_jvm",

--- a/framework/graph/BUILD
+++ b/framework/graph/BUILD
@@ -65,5 +65,5 @@ kt_jvm_library(
 checkstyle_test(
     name = "checkstyle",
     include = glob(["*"]),
-    license_type = "agpl",
+    license_type = "agpl-header",
 )

--- a/framework/material/BUILD
+++ b/framework/material/BUILD
@@ -61,5 +61,5 @@ kt_jvm_library(
 checkstyle_test(
     name = "checkstyle",
     include = glob(["*", "*/*"]),
-    license_type = "agpl",
+    license_type = "agpl-header",
 )

--- a/framework/output/BUILD
+++ b/framework/output/BUILD
@@ -42,7 +42,7 @@ kt_jvm_library(
         "@vaticle_typedb_common//:common",
         "@vaticle_typedb_client_java//api:api",
         "@vaticle_typedb_client_java//common:common",
-        "@vaticle_typeql_lang_java//common:common",
+        "@vaticle_typeql//java/common:common",
 
         # External Maven Dependencies
         "@maven//:io_github_microutils_kotlin_logging_jvm",

--- a/framework/output/BUILD
+++ b/framework/output/BUILD
@@ -62,5 +62,5 @@ kt_jvm_library(
 checkstyle_test(
     name = "checkstyle",
     include = glob(["*"]),
-    license_type = "agpl",
+    license_type = "agpl-header",
 )

--- a/module/BUILD
+++ b/module/BUILD
@@ -55,5 +55,5 @@ kt_jvm_library(
 checkstyle_test(
     name = "checkstyle",
     include = glob(["*"]),
-    license_type = "agpl",
+    license_type = "agpl-header",
 )

--- a/module/connection/BUILD
+++ b/module/connection/BUILD
@@ -57,5 +57,5 @@ kt_jvm_library(
 checkstyle_test(
     name = "checkstyle",
     include = glob(["*"]),
-    license_type = "agpl",
+    license_type = "agpl-header",
 )

--- a/module/project/BUILD
+++ b/module/project/BUILD
@@ -59,5 +59,5 @@ kt_jvm_library(
 checkstyle_test(
     name = "checkstyle",
     include = glob(["*"]),
-    license_type = "agpl",
+    license_type = "agpl-header",
 )

--- a/module/role/BUILD
+++ b/module/role/BUILD
@@ -46,5 +46,5 @@ kt_jvm_library(
 checkstyle_test(
     name = "checkstyle",
     include = glob(["*"]),
-    license_type = "agpl",
+    license_type = "agpl-header",
 )

--- a/module/rule/BUILD
+++ b/module/rule/BUILD
@@ -46,5 +46,5 @@ kt_jvm_library(
 checkstyle_test(
     name = "checkstyle",
     include = glob(["*"]),
-    license_type = "agpl",
+    license_type = "agpl-header",
 )

--- a/module/type/BUILD
+++ b/module/type/BUILD
@@ -60,5 +60,5 @@ kt_jvm_library(
 checkstyle_test(
     name = "checkstyle",
     include = glob(["*"]),
-    license_type = "agpl",
+    license_type = "agpl-header",
 )

--- a/module/user/BUILD
+++ b/module/user/BUILD
@@ -46,5 +46,5 @@ kt_jvm_library(
 checkstyle_test(
     name = "checkstyle",
     include = glob(["*"]),
-    license_type = "agpl",
+    license_type = "agpl-header",
 )

--- a/resources/fonts/monaco/BUILD
+++ b/resources/fonts/monaco/BUILD
@@ -28,5 +28,5 @@ checkstyle_test(
     name = "checkstyle",
     include = glob(["*"]),
     exclude = glob(["*.ttf"]),
-    license_type = "agpl",
+    license_type = "agpl-header",
 )

--- a/resources/fonts/titilliumweb/BUILD
+++ b/resources/fonts/titilliumweb/BUILD
@@ -32,5 +32,5 @@ checkstyle_test(
     name = "checkstyle",
     include = glob(["*"]),
     exclude = glob(["*.ttf"]),
-    license_type = "agpl",
+    license_type = "agpl-header",
 )

--- a/resources/fonts/ubuntumono/BUILD
+++ b/resources/fonts/ubuntumono/BUILD
@@ -31,5 +31,5 @@ checkstyle_test(
     name = "checkstyle",
     include = glob(["*"]),
     exclude = glob(["*.ttf", "UFL.txt"]),
-    license_type = "agpl",
+    license_type = "agpl-header",
 )

--- a/resources/icons/fontawesome/BUILD
+++ b/resources/icons/fontawesome/BUILD
@@ -30,5 +30,5 @@ checkstyle_test(
     name = "checkstyle",
     include = glob(["*"]),
     exclude = glob(["*.ttf", "*.otf"]),
-    license_type = "agpl",
+    license_type = "agpl-header",
 )

--- a/resources/icons/vaticle/BUILD
+++ b/resources/icons/vaticle/BUILD
@@ -43,5 +43,5 @@ checkstyle_test(
     name = "checkstyle",
     include = glob(["*"]),
     exclude = glob(["*.png", "*.icns", "*.ico"]),
-    license_type = "agpl",
+    license_type = "agpl-header",
 )

--- a/resources/schemes/BUILD
+++ b/resources/schemes/BUILD
@@ -29,5 +29,5 @@ filegroup(
 checkstyle_test(
     name = "checkstyle",
     include = glob(["*"]),
-    license_type = "agpl",
+    license_type = "agpl-header",
 )

--- a/state/BUILD
+++ b/state/BUILD
@@ -46,5 +46,5 @@ kt_jvm_library(
 checkstyle_test(
     name = "checkstyle",
     include = glob(["*", "*/*"]),
-    license_type = "agpl",
+    license_type = "agpl-header",
 )

--- a/state/app/BUILD
+++ b/state/app/BUILD
@@ -48,5 +48,5 @@ kt_jvm_library(
 checkstyle_test(
     name = "checkstyle",
     include = glob(["*", "*/*"]),
-    license_type = "agpl",
+    license_type = "agpl-header",
 )

--- a/state/common/BUILD
+++ b/state/common/BUILD
@@ -43,5 +43,5 @@ kt_jvm_library(
 checkstyle_test(
     name = "checkstyle",
     include = glob(["*", "*/*"]),
-    license_type = "agpl",
+    license_type = "agpl-header",
 )

--- a/state/connection/BUILD
+++ b/state/connection/BUILD
@@ -52,5 +52,5 @@ kt_jvm_library(
 checkstyle_test(
     name = "checkstyle",
     include = glob(["*", "*/*"]),
-    license_type = "agpl",
+    license_type = "agpl-header",
 )

--- a/state/connection/BUILD
+++ b/state/connection/BUILD
@@ -37,8 +37,8 @@ kt_jvm_library(
         "@vaticle_typedb_client_java//api:api",
         "@vaticle_typedb_client_java//common:common",
         "@vaticle_typedb_common//:common",
-        "@vaticle_typeql_lang_java//query:query",
-        "@vaticle_typeql_lang_java//:typeql-lang",
+        "@vaticle_typeql//java/query:query",
+        "@vaticle_typeql//java:typeql-lang",
 
         # External Maven Dependencies
         "@maven//:io_github_microutils_kotlin_logging_jvm",

--- a/state/page/BUILD
+++ b/state/page/BUILD
@@ -44,5 +44,5 @@ kt_jvm_library(
 checkstyle_test(
     name = "checkstyle",
     include = glob(["*", "*/*"]),
-    license_type = "agpl",
+    license_type = "agpl-header",
 )

--- a/state/project/BUILD
+++ b/state/project/BUILD
@@ -49,5 +49,5 @@ kt_jvm_library(
 checkstyle_test(
     name = "checkstyle",
     include = glob(["*", "*/*"]),
-    license_type = "agpl",
+    license_type = "agpl-header",
 )

--- a/state/schema/BUILD
+++ b/state/schema/BUILD
@@ -51,5 +51,5 @@ kt_jvm_library(
 checkstyle_test(
     name = "checkstyle",
     include = glob(["*", "*/*"]),
-    license_type = "agpl",
+    license_type = "agpl-header",
 )

--- a/state/schema/BUILD
+++ b/state/schema/BUILD
@@ -37,7 +37,7 @@ kt_jvm_library(
         # External Vaticle Dependencies
         "@vaticle_typedb_client_java//api:api",
         "@vaticle_typedb_client_java//common:common",
-        "@vaticle_typeql_lang_java//common:common",
+        "@vaticle_typeql//java/common:common",
 
         # External Maven Dependencies
         "@maven//:io_github_microutils_kotlin_logging_jvm",


### PR DESCRIPTION
## What is the goal of this PR?

We update the copyright header year to 2022, and introduce a test that ensures that the license text is correct.

## What are the changes implemented in this PR?

* Bring all the `checkstyle_test()` invocations in line with the updated definition in dependencies;
* Replace all references to `typeql-lang-java` with `typeql/java`;
* Use checkstyle to confirm that the license text is correct.
