### PR TITLE
Expand .gitignore to include IDE and OS-specific folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,12 +15,44 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-# OSX
+# Mac
 .DS_Store
 
 # Bazel
 bazel-*
 
-# IntelliJ
-.idea
-.ijwb
+# IDE
+.idea/
+*.iml
+*.ipr
+*.iws
+*.geany
+.ijwb/
+
+# TypeDB Studio
+.typedb-studio
+
+# VS Code
+.vscode/
+.settings/
+.project
+.classpath
+
+# Eclipse
+.metadata/
+
+# Compiled
+dist/
+out/
+*.class
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml #
+hs_err_pid*
+
+# Log
+logs/
+*.log
+
+# VIM swap
+*.swp
+*.swo

--- a/.gitignore
+++ b/.gitignore
@@ -15,13 +15,13 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-# Mac
+# macOS
 .DS_Store
 
 # Bazel
 bazel-*
 
-# IDE
+# IntelliJ IDEA
 .idea/
 *.iml
 *.ipr

--- a/.gitignore
+++ b/.gitignore
@@ -41,11 +41,6 @@ bazel-*
 # Eclipse
 .metadata/
 
-# Compiled
-dist/
-out/
-*.class
-
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml #
 hs_err_pid*
 


### PR DESCRIPTION
## What is the goal of this PR?

We want it to be easier for developers to use other IDEs and OSes in the course of contributing to this repo without having to carefully manage what files get included in their PRs.

## What are the changes implemented in this PR?

We have added more ignored files and folders to make it easier for developers to contribute to this repository, namely:
- VSCode
- Eclipse
- VIM
- TypeDB Studio
- Miscellaneous tooling files
