### PR TITLE
Migrate and stabilise Studio test suite

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -36,9 +36,6 @@ build:
     test-integration:
       image: vaticle-ubuntu-20.04
       command: |
-        bazel run //:typedb-extractor -- dist/typedb-all-linux
-        sudo systemd-run ./dist/typedb-all-linux/typedb server
-        sleep 60
         bazel build //test/integration/...
         bazel test $(bazel query 'kind(kt_jvm_test, //test/integration/...)') --test_output=streamed --spawn_strategy=local
 

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -37,7 +37,8 @@ build:
       image: vaticle-ubuntu-20.04
       command: |
         bazel build //test/integration/...
-        bazel test $(bazel query 'kind(kt_jvm_test, //test/integration/...)') --jobs=1 --spawn_strategy=local
+        bazel test //test/integration/... --jobs=1 --spawn_strategy=local
+
 
 release:
   #  filter:

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -63,6 +63,37 @@ build:
         bazel build //test/integration/...
         bazel test $(bazel query 'kind(kt_jvm_test, //test/integration/...)') --test_output=streamed --spawn_strategy=local
 
+    test-integration6:
+      image: vaticle-ubuntu-20.04
+      command: |
+        bazel build //test/integration/...
+        bazel test $(bazel query 'kind(kt_jvm_test, //test/integration/...)') --test_output=streamed --spawn_strategy=local
+
+    test-integration7:
+      image: vaticle-ubuntu-20.04
+      command: |
+        bazel build //test/integration/...
+        bazel test $(bazel query 'kind(kt_jvm_test, //test/integration/...)') --test_output=streamed --spawn_strategy=local
+
+    test-integration8:
+      image: vaticle-ubuntu-20.04
+      command: |
+        bazel build //test/integration/...
+        bazel test $(bazel query 'kind(kt_jvm_test, //test/integration/...)') --test_output=streamed --spawn_strategy=local
+
+    test-integration9:
+      image: vaticle-ubuntu-20.04
+      command: |
+        bazel build //test/integration/...
+        bazel test $(bazel query 'kind(kt_jvm_test, //test/integration/...)') --test_output=streamed --spawn_strategy=local
+
+    test-integration10:
+      image: vaticle-ubuntu-20.04
+      command: |
+        bazel build //test/integration/...
+        bazel test $(bazel query 'kind(kt_jvm_test, //test/integration/...)') --test_output=streamed --spawn_strategy=local
+
+
 release:
   #  filter:
   #    owner: vaticle

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -39,6 +39,30 @@ build:
         bazel build //test/integration/...
         bazel test $(bazel query 'kind(kt_jvm_test, //test/integration/...)') --test_output=streamed --spawn_strategy=local
 
+    test-integration2:
+      image: vaticle-ubuntu-20.04
+      command: |
+        bazel build //test/integration/...
+        bazel test $(bazel query 'kind(kt_jvm_test, //test/integration/...)') --test_output=streamed --spawn_strategy=local
+
+    test-integration3:
+      image: vaticle-ubuntu-20.04
+      command: |
+        bazel build //test/integration/...
+        bazel test $(bazel query 'kind(kt_jvm_test, //test/integration/...)') --test_output=streamed --spawn_strategy=local
+
+    test-integration4:
+      image: vaticle-ubuntu-20.04
+      command: |
+        bazel build //test/integration/...
+        bazel test $(bazel query 'kind(kt_jvm_test, //test/integration/...)') --test_output=streamed --spawn_strategy=local
+
+    test-integration5:
+      image: vaticle-ubuntu-20.04
+      command: |
+        bazel build //test/integration/...
+        bazel test $(bazel query 'kind(kt_jvm_test, //test/integration/...)') --test_output=streamed --spawn_strategy=local
+
 release:
   #  filter:
   #    owner: vaticle

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -39,61 +39,6 @@ build:
         bazel build //test/integration/...
         bazel test $(bazel query 'kind(kt_jvm_test, //test/integration/...)') --test_output=streamed --spawn_strategy=local
 
-    test-integration2:
-      image: vaticle-ubuntu-20.04
-      command: |
-        bazel build //test/integration/...
-        bazel test $(bazel query 'kind(kt_jvm_test, //test/integration/...)') --test_output=streamed --spawn_strategy=local
-
-    test-integration3:
-      image: vaticle-ubuntu-20.04
-      command: |
-        bazel build //test/integration/...
-        bazel test $(bazel query 'kind(kt_jvm_test, //test/integration/...)') --test_output=streamed --spawn_strategy=local
-
-    test-integration4:
-      image: vaticle-ubuntu-20.04
-      command: |
-        bazel build //test/integration/...
-        bazel test $(bazel query 'kind(kt_jvm_test, //test/integration/...)') --test_output=streamed --spawn_strategy=local
-
-    test-integration5:
-      image: vaticle-ubuntu-20.04
-      command: |
-        bazel build //test/integration/...
-        bazel test $(bazel query 'kind(kt_jvm_test, //test/integration/...)') --test_output=streamed --spawn_strategy=local
-
-    test-integration6:
-      image: vaticle-ubuntu-20.04
-      command: |
-        bazel build //test/integration/...
-        bazel test $(bazel query 'kind(kt_jvm_test, //test/integration/...)') --test_output=streamed --spawn_strategy=local
-
-    test-integration7:
-      image: vaticle-ubuntu-20.04
-      command: |
-        bazel build //test/integration/...
-        bazel test $(bazel query 'kind(kt_jvm_test, //test/integration/...)') --test_output=streamed --spawn_strategy=local
-
-    test-integration8:
-      image: vaticle-ubuntu-20.04
-      command: |
-        bazel build //test/integration/...
-        bazel test $(bazel query 'kind(kt_jvm_test, //test/integration/...)') --test_output=streamed --spawn_strategy=local
-
-    test-integration9:
-      image: vaticle-ubuntu-20.04
-      command: |
-        bazel build //test/integration/...
-        bazel test $(bazel query 'kind(kt_jvm_test, //test/integration/...)') --test_output=streamed --spawn_strategy=local
-
-    test-integration10:
-      image: vaticle-ubuntu-20.04
-      command: |
-        bazel build //test/integration/...
-        bazel test $(bazel query 'kind(kt_jvm_test, //test/integration/...)') --test_output=streamed --spawn_strategy=local
-
-
 release:
   #  filter:
   #    owner: vaticle

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -37,7 +37,7 @@ build:
       image: vaticle-ubuntu-20.04
       command: |
         bazel build //test/integration/...
-        bazel test $(bazel query 'kind(kt_jvm_test, //test/integration/...)') --jobs=1
+        bazel test $(bazel query 'kind(kt_jvm_test, //test/integration/...)') --jobs=1 --spawn_strategy=local
 
 release:
   #  filter:

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -37,8 +37,7 @@ build:
       image: vaticle-ubuntu-20.04
       command: |
         bazel build //test/integration/...
-        bazel test //test/integration/... --jobs=1 --spawn_strategy=local
-
+        bazel test $(bazel query '//test/integration/... except kind(checkstyle_test, //test/integration/...)') --jobs=1 --spawn_strategy=local
 
 release:
   #  filter:

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -28,7 +28,7 @@ build:
       command: |
         bazel build //...
         bazel run @vaticle_dependencies//tool/checkstyle:test-coverage
-        bazel test $(bazel query 'kind(checkstyle_test, //...)') --test_output=streamed
+        bazel test $(bazel query 'kind(checkstyle_test, //...)')
     test-unit:
       image: vaticle-ubuntu-20.04
       command: |
@@ -37,7 +37,7 @@ build:
       image: vaticle-ubuntu-20.04
       command: |
         bazel build //test/integration/...
-        bazel test $(bazel query 'kind(kt_jvm_test, //test/integration/...)') --test_output=streamed --spawn_strategy=local
+        bazel test $(bazel query 'kind(kt_jvm_test, //test/integration/...)') --jobs=1
 
 release:
   #  filter:

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -34,8 +34,8 @@ def vaticle_force_graph():
 def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
-        remote = "https://github.com/jamesreprise/typedb-common",
-        commit = "499a4b6a909c467ba268d870f48ee9c127a6b448" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        remote = "https://github.com/vaticle/typedb-common",
+        commit = "3ac0c1069986f8f5dc90aebf06facfb2cb2016f1" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_client_java():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -32,10 +32,14 @@ def vaticle_force_graph():
     )
 
 def vaticle_typedb_common():
-    git_repository(
+#    git_repository(
+#        name = "vaticle_typedb_common",
+#        remote = "https://github.com/vaticle/typedb-common",
+#        commit = "f0dd708adaea9fe1fdc3699180797a12166d33e8" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+#    )
+    native.local_repository(
         name = "vaticle_typedb_common",
-        remote = "https://github.com/vaticle/typedb-common",
-        commit = "f0dd708adaea9fe1fdc3699180797a12166d33e8" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        path = "../typedb-common",
     )
 
 def vaticle_typedb_client_java():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -35,7 +35,7 @@ def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
         remote = "https://github.com/jamesreprise/typedb-common",
-        commit = "1449a1bdb550efb481f0c511b025b5bfe575263b" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        commit = "499a4b6a909c467ba268d870f48ee9c127a6b448" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_client_java():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -32,14 +32,10 @@ def vaticle_force_graph():
     )
 
 def vaticle_typedb_common():
-#    git_repository(
-#        name = "vaticle_typedb_common",
-#        remote = "https://github.com/vaticle/typedb-common",
-#        commit = "f0dd708adaea9fe1fdc3699180797a12166d33e8" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
-#    )
-    native.local_repository(
+    git_repository(
         name = "vaticle_typedb_common",
-        path = "../typedb-common",
+        remote = "https://github.com/jamesreprise/typedb-common",
+        commit = "1449a1bdb550efb481f0c511b025b5bfe575263b" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_client_java():

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -69,7 +69,6 @@ kt_jvm_library(
         "@vaticle_typeql//java/common:common",
         "@vaticle_typeql//java/query:query",
 
-
         # External Maven Dependencies
         "@maven//:junit_junit",
         "@maven//:org_jetbrains_compose_runtime_runtime_desktop",

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -17,7 +17,7 @@
 
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library", "kt_jvm_test")
-load("@vaticle_typedb_common//test:rules.bzl", "typedb_kotlin_test")
+load("@vaticle_typedb_common//test:rules.bzl", "typedb_kt_test")
 
 package(default_visibility = ["//:__pkg__"])
 
@@ -51,22 +51,24 @@ kt_jvm_library(
     runtime_deps = skiko_runtime_platform,
     deps = [
         "//:studio",
+        "//framework/material",
+        "//framework/common",
         "//state",
         "//state/app",
+        "//state/common",
         "//state/connection",
         "//state/project",
         "//state/page",
-        "//state/common",
-        "//framework/material",
-        "//framework/common",
 
         # External Vaticle Dependencies
         "@vaticle_typedb_client_java//api",
         "@vaticle_typedb_client_java//:client-java",
         "@vaticle_typedb_common//:common",
+        "@vaticle_typedb_common//test:typedb-runner",
         "@vaticle_typeql//java:typeql-lang",
         "@vaticle_typeql//java/common:common",
         "@vaticle_typeql//java/query:query",
+
 
         # External Maven Dependencies
         "@maven//:junit_junit",
@@ -88,9 +90,6 @@ kt_jvm_library(
         "//:studio",
         "//state",
 
-        # External Vaticle Dependencies
-        "@vaticle_typedb_common//test:typedb-runner",
-
         # External Maven Dependencies
         "@maven//:junit_junit",
         "@maven//:org_jetbrains_compose_runtime_runtime_desktop",
@@ -102,7 +101,7 @@ kt_jvm_library(
     ],
 )
 
-typedb_kotlin_test(
+typedb_kt_test(
     name = "test-quickstart",
     srcs = ["QuickstartTest.kt"],
     data = ["//test/data:query-string-files"],
@@ -115,7 +114,7 @@ typedb_kotlin_test(
 )
 
 
-typedb_kotlin_test(
+kt_jvm_test(
     name = "test-projectbrowser",
     srcs = ["ProjectBrowserTest.kt"],
     data = ["//test/data:sample-file-structure-files"],
@@ -123,15 +122,12 @@ typedb_kotlin_test(
     runtime_deps = skiko_runtime_platform,
     deps = compose_test_libraries + [
         "//state",
+        "//state/page",
         "//state/project",
-        "//state/page"
     ],
-    server_mac_artifact = "@vaticle_typedb_artifact_mac//file",
-    server_linux_artifact = "@vaticle_typedb_artifact_linux//file",
-    server_windows_artifact = "@vaticle_typedb_artifact_windows//file",
 )
 
-typedb_kotlin_test(
+typedb_kt_test(
     name = "test-texteditor",
     srcs = ["TextEditorTest.kt"],
     data = ["//test/data:sample-file-structure-files", "//test/data:query-string-files"],
@@ -152,7 +148,7 @@ typedb_kotlin_test(
     server_windows_artifact = "@vaticle_typedb_artifact_windows//file",
 )
 
-typedb_kotlin_test(
+typedb_kt_test(
     name = "test-typebrowser",
     srcs = ["TypeBrowserTest.kt"],
     data = ["//test/data:sample-file-structure-files", "//test/data:query-string-files"],
@@ -160,11 +156,12 @@ typedb_kotlin_test(
     runtime_deps = skiko_runtime_platform,
     deps = compose_test_libraries + [
         "//state",
+        "//state/app",
         "//state/common",
-        "//state/page",
-        "//state/project",
-        "//state/schema",
         "//state/connection",
+        "//state/project",
+        "//state/page",
+        "//state/schema",
 
         "@vaticle_typedb_client_java//api",
     ],

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -17,6 +17,7 @@
 
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library", "kt_jvm_test")
+load("@vaticle_typedb_common//test:rules.bzl", "typedb_kotlin_test")
 
 package(default_visibility = ["//:__pkg__"])
 
@@ -87,6 +88,9 @@ kt_jvm_library(
         "//:studio",
         "//state",
 
+        # External Vaticle Dependencies
+        "@vaticle_typedb_common//test:typedb-runner",
+
         # External Maven Dependencies
         "@maven//:junit_junit",
         "@maven//:org_jetbrains_compose_runtime_runtime_desktop",
@@ -98,17 +102,20 @@ kt_jvm_library(
     ],
 )
 
-kt_jvm_test(
+typedb_kotlin_test(
     name = "test-quickstart",
     srcs = ["QuickstartTest.kt"],
     data = ["//test/data:query-string-files"],
     test_class = "com.vaticle.typedb.studio.test.integration.QuickstartTest",
     runtime_deps = skiko_runtime_platform,
-    deps = compose_test_libraries
+    deps = compose_test_libraries,
+    server_mac_artifact = "@vaticle_typedb_artifact_mac//file",
+    server_linux_artifact = "@vaticle_typedb_artifact_linux//file",
+    server_windows_artifact = "@vaticle_typedb_artifact_windows//file",
 )
 
 
-kt_jvm_test(
+typedb_kotlin_test(
     name = "test-projectbrowser",
     srcs = ["ProjectBrowserTest.kt"],
     data = ["//test/data:sample-file-structure-files"],
@@ -118,10 +125,13 @@ kt_jvm_test(
         "//state",
         "//state/project",
         "//state/page"
-    ]
+    ],
+    server_mac_artifact = "@vaticle_typedb_artifact_mac//file",
+    server_linux_artifact = "@vaticle_typedb_artifact_linux//file",
+    server_windows_artifact = "@vaticle_typedb_artifact_windows//file",
 )
 
-kt_jvm_test(
+typedb_kotlin_test(
     name = "test-texteditor",
     srcs = ["TextEditorTest.kt"],
     data = ["//test/data:sample-file-structure-files", "//test/data:query-string-files"],
@@ -136,10 +146,13 @@ kt_jvm_test(
         "//state/page",
 
         "@vaticle_typedb_client_java//api",
-    ]
+    ],
+    server_mac_artifact = "@vaticle_typedb_artifact_mac//file",
+    server_linux_artifact = "@vaticle_typedb_artifact_linux//file",
+    server_windows_artifact = "@vaticle_typedb_artifact_windows//file",
 )
 
-kt_jvm_test(
+typedb_kotlin_test(
     name = "test-typebrowser",
     srcs = ["TypeBrowserTest.kt"],
     data = ["//test/data:sample-file-structure-files", "//test/data:query-string-files"],
@@ -154,7 +167,10 @@ kt_jvm_test(
         "//state/connection",
 
         "@vaticle_typedb_client_java//api",
-    ]
+    ],
+    server_mac_artifact = "@vaticle_typedb_artifact_mac//file",
+    server_linux_artifact = "@vaticle_typedb_artifact_linux//file",
+    server_windows_artifact = "@vaticle_typedb_artifact_windows//file",
 )
 
 checkstyle_test(

--- a/test/integration/IntegrationTest.kt
+++ b/test/integration/IntegrationTest.kt
@@ -20,30 +20,18 @@
 package com.vaticle.typedb.studio.test.integration
 
 import androidx.compose.ui.test.junit4.createComposeRule
-import com.vaticle.typedb.common.test.core.TypeDBCoreRunner
 import com.vaticle.typedb.studio.state.StudioState
-import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import java.util.UUID
 
 abstract class IntegrationTest {
     lateinit var testID: String
-    lateinit var typeDB: TypeDBCoreRunner
-    lateinit var address: String
 
     @Before
     fun setupTest() {
         StudioState.init()
         testID = UUID.randomUUID().toString()
-        typeDB = TypeDBCoreRunner()
-        typeDB.start()
-        address = typeDB.address()
-    }
-
-    @After
-    fun teardownTest() {
-        typeDB.stop()
     }
 
     @get:Rule

--- a/test/integration/IntegrationTest.kt
+++ b/test/integration/IntegrationTest.kt
@@ -25,6 +25,20 @@ import org.junit.Before
 import org.junit.Rule
 import java.util.UUID
 
+/**
+ * Some of these tests use delay!
+ *
+ * The rationale for this is that substituting in stub classes/methods would create a lot of friction from release to
+ * release as the tests would require updating to completely reflect all the internal state that changes with each
+ * function. As a heavily state-driven application, duplicating all of this functionality and accurately verifying that
+ * the duplicate is like-for-like is out of scope.
+ *
+ * The delays are:
+ *  - used only when necessary (some data is travelling between the test and TypeDB)
+ *  - generous with the amount of time for the required action.
+ *
+ * However, this is a source of non-determinism and a better and easier way may emerge.
+ */
 abstract class IntegrationTest {
     lateinit var testID: String
 

--- a/test/integration/IntegrationTest.kt
+++ b/test/integration/IntegrationTest.kt
@@ -20,19 +20,30 @@
 package com.vaticle.typedb.studio.test.integration
 
 import androidx.compose.ui.test.junit4.createComposeRule
+import com.vaticle.typedb.common.test.core.TypeDBCoreRunner
 import com.vaticle.typedb.studio.state.StudioState
+import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import java.util.UUID
-import kotlinx.coroutines.delay
 
 abstract class IntegrationTest {
     lateinit var testID: String
+    lateinit var typeDB: TypeDBCoreRunner
+    lateinit var address: String
 
     @Before
     fun setupTest() {
         StudioState.init()
         testID = UUID.randomUUID().toString()
+        typeDB = TypeDBCoreRunner()
+        typeDB.start()
+        address = typeDB.address()
+    }
+
+    @After
+    fun teardownTest() {
+        typeDB.stop()
     }
 
     @get:Rule

--- a/test/integration/ProjectBrowserTest.kt
+++ b/test/integration/ProjectBrowserTest.kt
@@ -27,7 +27,7 @@ import androidx.compose.ui.test.performClick
 import com.vaticle.typedb.studio.state.StudioState
 import com.vaticle.typedb.studio.test.integration.Utils.cloneAndOpenProject
 import com.vaticle.typedb.studio.test.integration.Utils.studioTest
-import com.vaticle.typedb.studio.test.integration.Utils.wait
+import com.vaticle.typedb.studio.test.integration.Utils.waitAndRecompose
 import com.vaticle.typedb.studio.test.integration.Utils.SAMPLE_DATA_PATH
 import com.vaticle.typedb.studio.test.integration.Utils.DOUBLE_CHEVRON_DOWN_ICON_STRING
 import com.vaticle.typedb.studio.test.integration.Utils.DOUBLE_CHEVRON_UP_ICON_STRING
@@ -43,10 +43,10 @@ class ProjectBrowserTest: IntegrationTest() {
             cloneAndOpenProject(composeRule, source = SAMPLE_DATA_PATH, destination = testID)
 
             StudioState.project.current!!.directory.asDirectory().tryCreateDirectory(createdDirectoryName)
-            wait(composeRule, Delays.RECOMPOSE)
+            waitAndRecompose(composeRule, Delays.RECOMPOSE)
 
             StudioState.project.current!!.reloadEntries()
-            wait(composeRule, Delays.RECOMPOSE)
+            waitAndRecompose(composeRule, Delays.RECOMPOSE)
 
             composeRule.onNodeWithText(createdDirectoryName).assertExists()
         }
@@ -60,10 +60,10 @@ class ProjectBrowserTest: IntegrationTest() {
             cloneAndOpenProject(composeRule, source = SAMPLE_DATA_PATH, destination = testID)
 
             StudioState.project.current!!.directory.asDirectory().tryCreateFile(createdFileName)
-            wait(composeRule, Delays.RECOMPOSE)
+            waitAndRecompose(composeRule, Delays.RECOMPOSE)
 
             StudioState.project.current!!.reloadEntries()
-            wait(composeRule, Delays.RECOMPOSE)
+            waitAndRecompose(composeRule, Delays.RECOMPOSE)
 
             composeRule.onNodeWithText(createdFileName).assertExists()
 
@@ -79,10 +79,10 @@ class ProjectBrowserTest: IntegrationTest() {
 
             StudioState.project.current!!.directory.entries.find { it.name == "file3" }!!.asFile()
                 .tryRename(renamedFileName)
-            wait(composeRule, Delays.RECOMPOSE)
+            waitAndRecompose(composeRule, Delays.RECOMPOSE)
 
             StudioState.project.current!!.reloadEntries()
-            wait(composeRule, Delays.RECOMPOSE)
+            waitAndRecompose(composeRule, Delays.RECOMPOSE)
 
             composeRule.onNodeWithText(renamedFileName).assertExists()
         }
@@ -94,10 +94,10 @@ class ProjectBrowserTest: IntegrationTest() {
             cloneAndOpenProject(composeRule, source = SAMPLE_DATA_PATH, destination = testID)
 
             StudioState.project.current!!.directory.entries.find { it.name == "file3" }!!.asFile().delete()
-            wait(composeRule, Delays.RECOMPOSE)
+            waitAndRecompose(composeRule, Delays.RECOMPOSE)
 
             StudioState.project.current!!.reloadEntries()
-            wait(composeRule, Delays.RECOMPOSE)
+            waitAndRecompose(composeRule, Delays.RECOMPOSE)
 
             composeRule.onNodeWithText("file3").assertDoesNotExist()
         }

--- a/test/integration/ProjectBrowserTest.kt
+++ b/test/integration/ProjectBrowserTest.kt
@@ -25,6 +25,10 @@ package com.vaticle.typedb.studio.test.integration
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.vaticle.typedb.studio.state.StudioState
+import com.vaticle.typedb.studio.test.integration.Utils.cloneAndOpenProject
+import com.vaticle.typedb.studio.test.integration.Utils.studioTest
+import com.vaticle.typedb.studio.test.integration.Utils.wait
+
 import org.junit.Test
 
 class ProjectBrowserTest: IntegrationTest() {
@@ -34,7 +38,7 @@ class ProjectBrowserTest: IntegrationTest() {
         studioTest(composeRule) {
             val createdDirectoryName = "created"
 
-            cloneAndOpenProject(composeRule, source = SAMPLE_DATA_PATH, destination = testID)
+            cloneAndOpenProject(composeRule, source = Utils.SAMPLE_DATA_PATH, destination = testID)
 
             StudioState.project.current!!.directory.asDirectory().tryCreateDirectory(createdDirectoryName)
             wait(composeRule, 500)
@@ -51,7 +55,7 @@ class ProjectBrowserTest: IntegrationTest() {
         studioTest(composeRule) {
             val createdFileName = "created"
 
-            cloneAndOpenProject(composeRule, source = SAMPLE_DATA_PATH, destination = testID)
+            cloneAndOpenProject(composeRule, source = Utils.SAMPLE_DATA_PATH, destination = testID)
 
             StudioState.project.current!!.directory.asDirectory().tryCreateFile(createdFileName)
             wait(composeRule, 500)
@@ -69,7 +73,7 @@ class ProjectBrowserTest: IntegrationTest() {
         studioTest(composeRule) {
             val renamedFileName = "renamed"
 
-            cloneAndOpenProject(composeRule, source = SAMPLE_DATA_PATH, destination = testID)
+            cloneAndOpenProject(composeRule, source = Utils.SAMPLE_DATA_PATH, destination = testID)
 
             StudioState.project.current!!.directory.entries.find { it.name == "file3" }!!.asFile()
                 .tryRename(renamedFileName)
@@ -85,7 +89,7 @@ class ProjectBrowserTest: IntegrationTest() {
     @Test
     fun deleteAFile() {
         studioTest(composeRule) {
-            cloneAndOpenProject(composeRule, source = SAMPLE_DATA_PATH, destination = testID)
+            cloneAndOpenProject(composeRule, source = Utils.SAMPLE_DATA_PATH, destination = testID)
 
             StudioState.project.current!!.directory.entries.find { it.name == "file3" }!!.asFile().delete()
             wait(composeRule, 500)
@@ -100,9 +104,9 @@ class ProjectBrowserTest: IntegrationTest() {
     @Test
     fun expandFolders() {
         studioTest(composeRule) {
-            cloneAndOpenProject(composeRule, source = SAMPLE_DATA_PATH, destination = testID)
+            cloneAndOpenProject(composeRule, source = Utils.SAMPLE_DATA_PATH, destination = testID)
 
-            composeRule.onNodeWithText(DOUBLE_CHEVRON_DOWN_ICON_STRING).performClick()
+            composeRule.onNodeWithText(Utils.DOUBLE_CHEVRON_DOWN_ICON_STRING).performClick()
             composeRule.waitForIdle()
 
             composeRule.onNodeWithText("file1_2").assertExists()
@@ -112,13 +116,13 @@ class ProjectBrowserTest: IntegrationTest() {
     @Test
     fun expandThenCollapseFolders() {
         studioTest(composeRule) {
-            cloneAndOpenProject(composeRule, source = SAMPLE_DATA_PATH, destination = testID)
+            cloneAndOpenProject(composeRule, source = Utils.SAMPLE_DATA_PATH, destination = testID)
 
-            composeRule.onNodeWithText(DOUBLE_CHEVRON_DOWN_ICON_STRING).performClick()
+            composeRule.onNodeWithText(Utils.DOUBLE_CHEVRON_DOWN_ICON_STRING).performClick()
             composeRule.waitForIdle()
             composeRule.onNodeWithText("file1_2").assertExists()
 
-            composeRule.onNodeWithText(DOUBLE_CHEVRON_UP_ICON_STRING).performClick()
+            composeRule.onNodeWithText(Utils.DOUBLE_CHEVRON_UP_ICON_STRING).performClick()
             composeRule.waitForIdle()
 
             composeRule.onNodeWithText(testID).assertExists()

--- a/test/integration/ProjectBrowserTest.kt
+++ b/test/integration/ProjectBrowserTest.kt
@@ -28,7 +28,6 @@ import com.vaticle.typedb.studio.state.StudioState
 import com.vaticle.typedb.studio.test.integration.Utils.cloneAndOpenProject
 import com.vaticle.typedb.studio.test.integration.Utils.studioTest
 import com.vaticle.typedb.studio.test.integration.Utils.wait
-
 import org.junit.Test
 
 class ProjectBrowserTest: IntegrationTest() {

--- a/test/integration/ProjectBrowserTest.kt
+++ b/test/integration/ProjectBrowserTest.kt
@@ -41,10 +41,10 @@ class ProjectBrowserTest: IntegrationTest() {
             cloneAndOpenProject(composeRule, source = Utils.SAMPLE_DATA_PATH, destination = testID)
 
             StudioState.project.current!!.directory.asDirectory().tryCreateDirectory(createdDirectoryName)
-            wait(composeRule, 500)
+            wait(composeRule, 750)
 
             StudioState.project.current!!.reloadEntries()
-            wait(composeRule, 500)
+            wait(composeRule, 750)
 
             composeRule.onNodeWithText(createdDirectoryName).assertExists()
         }
@@ -58,10 +58,10 @@ class ProjectBrowserTest: IntegrationTest() {
             cloneAndOpenProject(composeRule, source = Utils.SAMPLE_DATA_PATH, destination = testID)
 
             StudioState.project.current!!.directory.asDirectory().tryCreateFile(createdFileName)
-            wait(composeRule, 500)
+            wait(composeRule, 750)
 
             StudioState.project.current!!.reloadEntries()
-            wait(composeRule, 500)
+            wait(composeRule, 750)
 
             composeRule.onNodeWithText(createdFileName).assertExists()
 
@@ -77,10 +77,10 @@ class ProjectBrowserTest: IntegrationTest() {
 
             StudioState.project.current!!.directory.entries.find { it.name == "file3" }!!.asFile()
                 .tryRename(renamedFileName)
-            wait(composeRule, 500)
+            wait(composeRule, 750)
 
             StudioState.project.current!!.reloadEntries()
-            wait(composeRule, 500)
+            wait(composeRule, 750)
 
             composeRule.onNodeWithText(renamedFileName).assertExists()
         }
@@ -92,10 +92,10 @@ class ProjectBrowserTest: IntegrationTest() {
             cloneAndOpenProject(composeRule, source = Utils.SAMPLE_DATA_PATH, destination = testID)
 
             StudioState.project.current!!.directory.entries.find { it.name == "file3" }!!.asFile().delete()
-            wait(composeRule, 500)
+            wait(composeRule, 750)
 
             StudioState.project.current!!.reloadEntries()
-            wait(composeRule, 500)
+            wait(composeRule, 750)
 
             composeRule.onNodeWithText("file3").assertDoesNotExist()
         }

--- a/test/integration/ProjectBrowserTest.kt
+++ b/test/integration/ProjectBrowserTest.kt
@@ -27,7 +27,7 @@ import androidx.compose.ui.test.performClick
 import com.vaticle.typedb.studio.state.StudioState
 import com.vaticle.typedb.studio.test.integration.Utils.cloneAndOpenProject
 import com.vaticle.typedb.studio.test.integration.Utils.studioTest
-import com.vaticle.typedb.studio.test.integration.Utils.waitAndRecompose
+import com.vaticle.typedb.studio.test.integration.Utils.delayAndRecompose
 import com.vaticle.typedb.studio.test.integration.Utils.SAMPLE_DATA_PATH
 import com.vaticle.typedb.studio.test.integration.Utils.DOUBLE_CHEVRON_DOWN_ICON_STRING
 import com.vaticle.typedb.studio.test.integration.Utils.DOUBLE_CHEVRON_UP_ICON_STRING
@@ -43,10 +43,10 @@ class ProjectBrowserTest: IntegrationTest() {
             cloneAndOpenProject(composeRule, source = SAMPLE_DATA_PATH, destination = testID)
 
             StudioState.project.current!!.directory.asDirectory().tryCreateDirectory(createdDirectoryName)
-            waitAndRecompose(composeRule, Delays.RECOMPOSE)
+            delayAndRecompose(composeRule)
 
             StudioState.project.current!!.reloadEntries()
-            waitAndRecompose(composeRule, Delays.RECOMPOSE)
+            delayAndRecompose(composeRule)
 
             composeRule.onNodeWithText(createdDirectoryName).assertExists()
         }
@@ -60,10 +60,10 @@ class ProjectBrowserTest: IntegrationTest() {
             cloneAndOpenProject(composeRule, source = SAMPLE_DATA_PATH, destination = testID)
 
             StudioState.project.current!!.directory.asDirectory().tryCreateFile(createdFileName)
-            waitAndRecompose(composeRule, Delays.RECOMPOSE)
+            delayAndRecompose(composeRule)
 
             StudioState.project.current!!.reloadEntries()
-            waitAndRecompose(composeRule, Delays.RECOMPOSE)
+            delayAndRecompose(composeRule)
 
             composeRule.onNodeWithText(createdFileName).assertExists()
 
@@ -79,10 +79,10 @@ class ProjectBrowserTest: IntegrationTest() {
 
             StudioState.project.current!!.directory.entries.find { it.name == "file3" }!!.asFile()
                 .tryRename(renamedFileName)
-            waitAndRecompose(composeRule, Delays.RECOMPOSE)
+            delayAndRecompose(composeRule)
 
             StudioState.project.current!!.reloadEntries()
-            waitAndRecompose(composeRule, Delays.RECOMPOSE)
+            delayAndRecompose(composeRule)
 
             composeRule.onNodeWithText(renamedFileName).assertExists()
         }
@@ -94,10 +94,10 @@ class ProjectBrowserTest: IntegrationTest() {
             cloneAndOpenProject(composeRule, source = SAMPLE_DATA_PATH, destination = testID)
 
             StudioState.project.current!!.directory.entries.find { it.name == "file3" }!!.asFile().delete()
-            waitAndRecompose(composeRule, Delays.RECOMPOSE)
+            delayAndRecompose(composeRule)
 
             StudioState.project.current!!.reloadEntries()
-            waitAndRecompose(composeRule, Delays.RECOMPOSE)
+            delayAndRecompose(composeRule)
 
             composeRule.onNodeWithText("file3").assertDoesNotExist()
         }

--- a/test/integration/ProjectBrowserTest.kt
+++ b/test/integration/ProjectBrowserTest.kt
@@ -28,6 +28,9 @@ import com.vaticle.typedb.studio.state.StudioState
 import com.vaticle.typedb.studio.test.integration.Utils.cloneAndOpenProject
 import com.vaticle.typedb.studio.test.integration.Utils.studioTest
 import com.vaticle.typedb.studio.test.integration.Utils.wait
+import com.vaticle.typedb.studio.test.integration.Utils.SAMPLE_DATA_PATH
+import com.vaticle.typedb.studio.test.integration.Utils.DOUBLE_CHEVRON_DOWN_ICON_STRING
+import com.vaticle.typedb.studio.test.integration.Utils.DOUBLE_CHEVRON_UP_ICON_STRING
 import org.junit.Test
 
 class ProjectBrowserTest: IntegrationTest() {
@@ -37,13 +40,13 @@ class ProjectBrowserTest: IntegrationTest() {
         studioTest(composeRule) {
             val createdDirectoryName = "created"
 
-            cloneAndOpenProject(composeRule, source = Utils.SAMPLE_DATA_PATH, destination = testID)
+            cloneAndOpenProject(composeRule, source = SAMPLE_DATA_PATH, destination = testID)
 
             StudioState.project.current!!.directory.asDirectory().tryCreateDirectory(createdDirectoryName)
-            wait(composeRule, 750)
+            wait(composeRule, Delays.RECOMPOSE)
 
             StudioState.project.current!!.reloadEntries()
-            wait(composeRule, 750)
+            wait(composeRule, Delays.RECOMPOSE)
 
             composeRule.onNodeWithText(createdDirectoryName).assertExists()
         }
@@ -54,13 +57,13 @@ class ProjectBrowserTest: IntegrationTest() {
         studioTest(composeRule) {
             val createdFileName = "created"
 
-            cloneAndOpenProject(composeRule, source = Utils.SAMPLE_DATA_PATH, destination = testID)
+            cloneAndOpenProject(composeRule, source = SAMPLE_DATA_PATH, destination = testID)
 
             StudioState.project.current!!.directory.asDirectory().tryCreateFile(createdFileName)
-            wait(composeRule, 750)
+            wait(composeRule, Delays.RECOMPOSE)
 
             StudioState.project.current!!.reloadEntries()
-            wait(composeRule, 750)
+            wait(composeRule, Delays.RECOMPOSE)
 
             composeRule.onNodeWithText(createdFileName).assertExists()
 
@@ -72,14 +75,14 @@ class ProjectBrowserTest: IntegrationTest() {
         studioTest(composeRule) {
             val renamedFileName = "renamed"
 
-            cloneAndOpenProject(composeRule, source = Utils.SAMPLE_DATA_PATH, destination = testID)
+            cloneAndOpenProject(composeRule, source = SAMPLE_DATA_PATH, destination = testID)
 
             StudioState.project.current!!.directory.entries.find { it.name == "file3" }!!.asFile()
                 .tryRename(renamedFileName)
-            wait(composeRule, 750)
+            wait(composeRule, Delays.RECOMPOSE)
 
             StudioState.project.current!!.reloadEntries()
-            wait(composeRule, 750)
+            wait(composeRule, Delays.RECOMPOSE)
 
             composeRule.onNodeWithText(renamedFileName).assertExists()
         }
@@ -88,13 +91,13 @@ class ProjectBrowserTest: IntegrationTest() {
     @Test
     fun deleteAFile() {
         studioTest(composeRule) {
-            cloneAndOpenProject(composeRule, source = Utils.SAMPLE_DATA_PATH, destination = testID)
+            cloneAndOpenProject(composeRule, source = SAMPLE_DATA_PATH, destination = testID)
 
             StudioState.project.current!!.directory.entries.find { it.name == "file3" }!!.asFile().delete()
-            wait(composeRule, 750)
+            wait(composeRule, Delays.RECOMPOSE)
 
             StudioState.project.current!!.reloadEntries()
-            wait(composeRule, 750)
+            wait(composeRule, Delays.RECOMPOSE)
 
             composeRule.onNodeWithText("file3").assertDoesNotExist()
         }
@@ -103,9 +106,9 @@ class ProjectBrowserTest: IntegrationTest() {
     @Test
     fun expandFolders() {
         studioTest(composeRule) {
-            cloneAndOpenProject(composeRule, source = Utils.SAMPLE_DATA_PATH, destination = testID)
+            cloneAndOpenProject(composeRule, source = SAMPLE_DATA_PATH, destination = testID)
 
-            composeRule.onNodeWithText(Utils.DOUBLE_CHEVRON_DOWN_ICON_STRING).performClick()
+            composeRule.onNodeWithText(DOUBLE_CHEVRON_DOWN_ICON_STRING).performClick()
             composeRule.waitForIdle()
 
             composeRule.onNodeWithText("file1_2").assertExists()
@@ -115,13 +118,13 @@ class ProjectBrowserTest: IntegrationTest() {
     @Test
     fun expandThenCollapseFolders() {
         studioTest(composeRule) {
-            cloneAndOpenProject(composeRule, source = Utils.SAMPLE_DATA_PATH, destination = testID)
+            cloneAndOpenProject(composeRule, source = SAMPLE_DATA_PATH, destination = testID)
 
-            composeRule.onNodeWithText(Utils.DOUBLE_CHEVRON_DOWN_ICON_STRING).performClick()
+            composeRule.onNodeWithText(DOUBLE_CHEVRON_DOWN_ICON_STRING).performClick()
             composeRule.waitForIdle()
             composeRule.onNodeWithText("file1_2").assertExists()
 
-            composeRule.onNodeWithText(Utils.DOUBLE_CHEVRON_UP_ICON_STRING).performClick()
+            composeRule.onNodeWithText(DOUBLE_CHEVRON_UP_ICON_STRING).performClick()
             composeRule.waitForIdle()
 
             composeRule.onNodeWithText(testID).assertExists()

--- a/test/integration/QuickstartTest.kt
+++ b/test/integration/QuickstartTest.kt
@@ -43,12 +43,12 @@ class QuickstartTest: IntegrationTest() {
     @Test
     fun Quickstart() {
         studioTest(composeRule) {
-            connectToTypeDB(composeRule, DB_ADDRESS)
+            connectToTypeDB(composeRule, address)
             createDatabase(composeRule, dbName = testID)
             cloneAndOpenProject(composeRule, source = TQL_DATA_PATH, destination = testID)
             writeSchemaInteractively(composeRule, dbName = testID, SCHEMA_FILE_NAME)
             writeDataInteractively(composeRule, dbName = testID, DATA_FILE_NAME)
-            verifyDataWrite(composeRule, dbName = testID, "$testID/$QUERY_FILE_NAME")
+            verifyDataWrite(composeRule, address, dbName = testID, "$testID/$QUERY_FILE_NAME")
         }
     }
 }

--- a/test/integration/QuickstartTest.kt
+++ b/test/integration/QuickstartTest.kt
@@ -29,6 +29,10 @@ import com.vaticle.typedb.studio.test.integration.Utils.cloneAndOpenProject
 import com.vaticle.typedb.studio.test.integration.Utils.writeSchemaInteractively
 import com.vaticle.typedb.studio.test.integration.Utils.writeDataInteractively
 import com.vaticle.typedb.studio.test.integration.Utils.verifyDataWrite
+import com.vaticle.typedb.studio.test.integration.Utils.SCHEMA_FILE_NAME
+import com.vaticle.typedb.studio.test.integration.Utils.DATA_FILE_NAME
+import com.vaticle.typedb.studio.test.integration.Utils.QUERY_FILE_NAME
+import com.vaticle.typedb.studio.test.integration.Utils.TQL_DATA_PATH
 import org.junit.Test
 
 /**
@@ -52,10 +56,10 @@ class QuickstartTest: IntegrationTest() {
         studioTestWithRunner(composeRule) { address ->
             connectToTypeDB(composeRule, address)
             createDatabase(composeRule, dbName = testID)
-            cloneAndOpenProject(composeRule, source = Utils.TQL_DATA_PATH, destination = testID)
-            writeSchemaInteractively(composeRule, dbName = testID, Utils.SCHEMA_FILE_NAME)
-            writeDataInteractively(composeRule, dbName = testID, Utils.DATA_FILE_NAME)
-            verifyDataWrite(composeRule, address, dbName = testID, "$testID/${Utils.QUERY_FILE_NAME}")
+            cloneAndOpenProject(composeRule, source = TQL_DATA_PATH, destination = testID)
+            writeSchemaInteractively(composeRule, dbName = testID, SCHEMA_FILE_NAME)
+            writeDataInteractively(composeRule, dbName = testID, DATA_FILE_NAME)
+            verifyDataWrite(composeRule, address, dbName = testID, "$testID/${QUERY_FILE_NAME}")
         }
     }
 }

--- a/test/integration/QuickstartTest.kt
+++ b/test/integration/QuickstartTest.kt
@@ -42,6 +42,7 @@ class QuickstartTest: IntegrationTest() {
 
     @Test
     fun Quickstart() {
+        println("Starting Quickstart.")
         studioTestWithRunner(composeRule) { address ->
             connectToTypeDB(composeRule, address)
             createDatabase(composeRule, dbName = testID)
@@ -50,5 +51,6 @@ class QuickstartTest: IntegrationTest() {
             writeDataInteractively(composeRule, dbName = testID, DATA_FILE_NAME)
             verifyDataWrite(composeRule, address, dbName = testID, "$testID/$QUERY_FILE_NAME")
         }
+        println("Finishing Quickstart.")
     }
 }

--- a/test/integration/QuickstartTest.kt
+++ b/test/integration/QuickstartTest.kt
@@ -35,20 +35,6 @@ import com.vaticle.typedb.studio.test.integration.Utils.QUERY_FILE_NAME
 import com.vaticle.typedb.studio.test.integration.Utils.TQL_DATA_PATH
 import org.junit.Test
 
-/**
- * Some of these tests use delay!
- *
- * The rationale for this is that substituting in stub classes/methods would create a lot of friction from release to
- * release as the tests would require updating to completely reflect all the internal state that changes with each
- * function. As a heavily state-driven application, duplicating all of this functionality and accurately verifying that
- * the duplicate is like-for-like is out of scope.
- *
- * The delays are:
- *  - used only when necessary (some data is travelling between the test and TypeDB)
- *  - generous with the amount of time for the required action.
- *
- * However, this is a source of non-determinism and a better and easier way may emerge.
- */
 class QuickstartTest: IntegrationTest() {
 
     @Test

--- a/test/integration/QuickstartTest.kt
+++ b/test/integration/QuickstartTest.kt
@@ -49,7 +49,6 @@ class QuickstartTest: IntegrationTest() {
 
     @Test
     fun Quickstart() {
-        println("Starting Quickstart.")
         studioTestWithRunner(composeRule) { address ->
             connectToTypeDB(composeRule, address)
             createDatabase(composeRule, dbName = testID)
@@ -58,6 +57,5 @@ class QuickstartTest: IntegrationTest() {
             writeDataInteractively(composeRule, dbName = testID, Utils.DATA_FILE_NAME)
             verifyDataWrite(composeRule, address, dbName = testID, "$testID/${Utils.QUERY_FILE_NAME}")
         }
-        println("Finishing Quickstart.")
     }
 }

--- a/test/integration/QuickstartTest.kt
+++ b/test/integration/QuickstartTest.kt
@@ -42,7 +42,7 @@ class QuickstartTest: IntegrationTest() {
 
     @Test
     fun Quickstart() {
-        studioTest(composeRule) {
+        studioTestWithRunner(composeRule) { address ->
             connectToTypeDB(composeRule, address)
             createDatabase(composeRule, dbName = testID)
             cloneAndOpenProject(composeRule, source = TQL_DATA_PATH, destination = testID)

--- a/test/integration/QuickstartTest.kt
+++ b/test/integration/QuickstartTest.kt
@@ -22,6 +22,13 @@
 
 package com.vaticle.typedb.studio.test.integration
 
+import com.vaticle.typedb.studio.test.integration.Utils.studioTestWithRunner
+import com.vaticle.typedb.studio.test.integration.Utils.connectToTypeDB
+import com.vaticle.typedb.studio.test.integration.Utils.createDatabase
+import com.vaticle.typedb.studio.test.integration.Utils.cloneAndOpenProject
+import com.vaticle.typedb.studio.test.integration.Utils.writeSchemaInteractively
+import com.vaticle.typedb.studio.test.integration.Utils.writeDataInteractively
+import com.vaticle.typedb.studio.test.integration.Utils.verifyDataWrite
 import org.junit.Test
 
 /**
@@ -46,10 +53,10 @@ class QuickstartTest: IntegrationTest() {
         studioTestWithRunner(composeRule) { address ->
             connectToTypeDB(composeRule, address)
             createDatabase(composeRule, dbName = testID)
-            cloneAndOpenProject(composeRule, source = TQL_DATA_PATH, destination = testID)
-            writeSchemaInteractively(composeRule, dbName = testID, SCHEMA_FILE_NAME)
-            writeDataInteractively(composeRule, dbName = testID, DATA_FILE_NAME)
-            verifyDataWrite(composeRule, address, dbName = testID, "$testID/$QUERY_FILE_NAME")
+            cloneAndOpenProject(composeRule, source = Utils.TQL_DATA_PATH, destination = testID)
+            writeSchemaInteractively(composeRule, dbName = testID, Utils.SCHEMA_FILE_NAME)
+            writeDataInteractively(composeRule, dbName = testID, Utils.DATA_FILE_NAME)
+            verifyDataWrite(composeRule, address, dbName = testID, "$testID/${Utils.QUERY_FILE_NAME}")
         }
         println("Finishing Quickstart.")
     }

--- a/test/integration/TextEditorTest.kt
+++ b/test/integration/TextEditorTest.kt
@@ -63,7 +63,6 @@ class TextEditorTest: IntegrationTest() {
 
     @Test
     fun schemaWriteAndCommit() {
-        println("Starting schemaWriteAndCommit.")
         studioTestWithRunner(composeRule) { address ->
         // We have to open a project to enable the '+' to create a new file.
             cloneAndOpenProject(composeRule, source = Utils.TQL_DATA_PATH, destination = testID)
@@ -82,12 +81,10 @@ class TextEditorTest: IntegrationTest() {
 
             StudioState.client.session.close()
         }
-        println("Finishing schemaWriteAndCommit.")
     }
 
     @Test
     fun dataWriteAndCommit() {
-        println("Starting dataWriteAndCommit.")
         studioTestWithRunner(composeRule) { address ->
         cloneAndOpenProject(composeRule, source = Utils.TQL_DATA_PATH, destination = testID)
             connectToTypeDB(composeRule, address)
@@ -96,12 +93,10 @@ class TextEditorTest: IntegrationTest() {
             writeDataInteractively(composeRule, dbName = testID, Utils.DATA_FILE_NAME)
             verifyDataWrite(composeRule, address, dbName = testID, "$testID/${Utils.QUERY_FILE_NAME}")
         }
-        println("Finishing dataWriteAndCommit.")
     }
 
     @Test
     fun schemaWriteAndRollback() {
-        println("Starting schemaWriteAndRollback.")
         studioTestWithRunner(composeRule) { address ->
             cloneAndOpenProject(composeRule, source = Utils.TQL_DATA_PATH, destination = testID)
             connectToTypeDB(composeRule, address)
@@ -125,6 +120,5 @@ class TextEditorTest: IntegrationTest() {
 
             StudioState.client.session.close()
         }
-        println("Finishing schemaWriteAndRollback.")
     }
 }

--- a/test/integration/TextEditorTest.kt
+++ b/test/integration/TextEditorTest.kt
@@ -26,6 +26,15 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.vaticle.typedb.client.api.TypeDBSession
 import com.vaticle.typedb.studio.state.StudioState
+import com.vaticle.typedb.studio.test.integration.Utils.studioTest
+import com.vaticle.typedb.studio.test.integration.Utils.studioTestWithRunner
+import com.vaticle.typedb.studio.test.integration.Utils.connectToTypeDB
+import com.vaticle.typedb.studio.test.integration.Utils.createDatabase
+import com.vaticle.typedb.studio.test.integration.Utils.cloneAndOpenProject
+import com.vaticle.typedb.studio.test.integration.Utils.wait
+import com.vaticle.typedb.studio.test.integration.Utils.writeSchemaInteractively
+import com.vaticle.typedb.studio.test.integration.Utils.writeDataInteractively
+import com.vaticle.typedb.studio.test.integration.Utils.verifyDataWrite
 import java.io.File
 import kotlin.test.assertTrue
 import org.junit.Test
@@ -36,13 +45,13 @@ class TextEditorTest: IntegrationTest() {
     fun makeAFileAndSaveIt() {
         studioTest(composeRule) {
         // We have to open a project to enable the '+' to create a new file.
-            val path = cloneAndOpenProject(composeRule, source = SAMPLE_DATA_PATH, destination = testID)
+            val path = cloneAndOpenProject(composeRule, source = Utils.SAMPLE_DATA_PATH, destination = testID)
 
-            composeRule.onNodeWithText(PLUS_ICON_STRING).performClick()
+            composeRule.onNodeWithText(Utils.PLUS_ICON_STRING).performClick()
             wait(composeRule, 500)
 
             // This sets saveFileDialog.file!! to the current file, so even though we can't see the window it is useful.
-            composeRule.onNodeWithText(SAVE_ICON_STRING).performClick()
+            composeRule.onNodeWithText(Utils.SAVE_ICON_STRING).performClick()
             val filePath = File("$path/Untitled1.tql").toPath()
             StudioState.project.saveFileDialog.file!!.trySave(filePath, true)
             StudioState.project.current!!.reloadEntries()
@@ -57,14 +66,14 @@ class TextEditorTest: IntegrationTest() {
         println("Starting schemaWriteAndCommit.")
         studioTestWithRunner(composeRule) { address ->
         // We have to open a project to enable the '+' to create a new file.
-            cloneAndOpenProject(composeRule, source = TQL_DATA_PATH, destination = testID)
+            cloneAndOpenProject(composeRule, source = Utils.TQL_DATA_PATH, destination = testID)
             connectToTypeDB(composeRule, address)
             createDatabase(composeRule, dbName = testID)
-            writeSchemaInteractively(composeRule, dbName = testID, SCHEMA_FILE_NAME)
+            writeSchemaInteractively(composeRule, dbName = testID, Utils.SCHEMA_FILE_NAME)
 
             StudioState.client.session.tryOpen(database = testID, TypeDBSession.Type.DATA)
 
-            composeRule.onNodeWithText(CHEVRON_UP_ICON_STRING).performClick()
+            composeRule.onNodeWithText(Utils.CHEVRON_UP_ICON_STRING).performClick()
             wait(composeRule, 500)
 
             // We can assert that the schema has been written successfully here as the schema
@@ -80,12 +89,12 @@ class TextEditorTest: IntegrationTest() {
     fun dataWriteAndCommit() {
         println("Starting dataWriteAndCommit.")
         studioTestWithRunner(composeRule) { address ->
-        cloneAndOpenProject(composeRule, source = TQL_DATA_PATH, destination = testID)
+        cloneAndOpenProject(composeRule, source = Utils.TQL_DATA_PATH, destination = testID)
             connectToTypeDB(composeRule, address)
             createDatabase(composeRule, dbName = testID)
-            writeSchemaInteractively(composeRule, dbName = testID, SCHEMA_FILE_NAME)
-            writeDataInteractively(composeRule, dbName = testID, DATA_FILE_NAME)
-            verifyDataWrite(composeRule, address, dbName = testID, "$testID/$QUERY_FILE_NAME")
+            writeSchemaInteractively(composeRule, dbName = testID, Utils.SCHEMA_FILE_NAME)
+            writeDataInteractively(composeRule, dbName = testID, Utils.DATA_FILE_NAME)
+            verifyDataWrite(composeRule, address, dbName = testID, "$testID/${Utils.QUERY_FILE_NAME}")
         }
         println("Finishing dataWriteAndCommit.")
     }
@@ -94,7 +103,7 @@ class TextEditorTest: IntegrationTest() {
     fun schemaWriteAndRollback() {
         println("Starting schemaWriteAndRollback.")
         studioTestWithRunner(composeRule) { address ->
-            cloneAndOpenProject(composeRule, source = TQL_DATA_PATH, destination = testID)
+            cloneAndOpenProject(composeRule, source = Utils.TQL_DATA_PATH, destination = testID)
             connectToTypeDB(composeRule, address)
             createDatabase(composeRule, dbName = testID)
 
@@ -105,11 +114,11 @@ class TextEditorTest: IntegrationTest() {
             composeRule.onNodeWithText("schema").performClick()
             composeRule.onNodeWithText("write").performClick()
 
-            StudioState.project.current!!.directory.entries.find { it.name == SCHEMA_FILE_NAME }!!.asFile().tryOpen()
+            StudioState.project.current!!.directory.entries.find { it.name == Utils.SCHEMA_FILE_NAME }!!.asFile().tryOpen()
 
-            composeRule.onNodeWithText(PLAY_ICON_STRING).performClick()
+            composeRule.onNodeWithText(Utils.PLAY_ICON_STRING).performClick()
             wait(composeRule, 500)
-            composeRule.onNodeWithText(ROLLBACK_ICON_STRING).performClick()
+            composeRule.onNodeWithText(Utils.ROLLBACK_ICON_STRING).performClick()
             wait(composeRule, 500)
 
             composeRule.onNodeWithText("repo-id").assertDoesNotExist()

--- a/test/integration/TextEditorTest.kt
+++ b/test/integration/TextEditorTest.kt
@@ -57,7 +57,7 @@ class TextEditorTest: IntegrationTest() {
         studioTest(composeRule) {
             // We have to open a project to enable the '+' to create a new file.
             cloneAndOpenProject(composeRule, source = TQL_DATA_PATH, destination = testID)
-            connectToTypeDB(composeRule, DB_ADDRESS)
+            connectToTypeDB(composeRule, address)
             createDatabase(composeRule, dbName = testID)
             writeSchemaInteractively(composeRule, dbName = testID, SCHEMA_FILE_NAME)
 
@@ -78,11 +78,11 @@ class TextEditorTest: IntegrationTest() {
     fun dataWriteAndCommit() {
         studioTest(composeRule) {
             cloneAndOpenProject(composeRule, source = TQL_DATA_PATH, destination = testID)
-            connectToTypeDB(composeRule, DB_ADDRESS)
+            connectToTypeDB(composeRule, address)
             createDatabase(composeRule, dbName = testID)
             writeSchemaInteractively(composeRule, dbName = testID, SCHEMA_FILE_NAME)
             writeDataInteractively(composeRule, dbName = testID, DATA_FILE_NAME)
-            verifyDataWrite(composeRule, dbName = testID, "$testID/$QUERY_FILE_NAME")
+            verifyDataWrite(composeRule, address, dbName = testID, "$testID/$QUERY_FILE_NAME")
         }
     }
 
@@ -90,7 +90,7 @@ class TextEditorTest: IntegrationTest() {
     fun schemaWriteAndRollback() {
         studioTest(composeRule) {
             cloneAndOpenProject(composeRule, source = TQL_DATA_PATH, destination = testID)
-            connectToTypeDB(composeRule, DB_ADDRESS)
+            connectToTypeDB(composeRule, address)
             createDatabase(composeRule, dbName = testID)
 
             StudioState.client.session.tryOpen(testID, TypeDBSession.Type.SCHEMA)

--- a/test/integration/TextEditorTest.kt
+++ b/test/integration/TextEditorTest.kt
@@ -54,6 +54,7 @@ class TextEditorTest: IntegrationTest() {
 
     @Test
     fun schemaWriteAndCommit() {
+        println("Starting schemaWriteAndCommit.")
         studioTestWithRunner(composeRule) { address ->
         // We have to open a project to enable the '+' to create a new file.
             cloneAndOpenProject(composeRule, source = TQL_DATA_PATH, destination = testID)
@@ -72,10 +73,12 @@ class TextEditorTest: IntegrationTest() {
 
             StudioState.client.session.close()
         }
+        println("Finishing schemaWriteAndCommit.")
     }
 
     @Test
     fun dataWriteAndCommit() {
+        println("Starting dataWriteAndCommit.")
         studioTestWithRunner(composeRule) { address ->
         cloneAndOpenProject(composeRule, source = TQL_DATA_PATH, destination = testID)
             connectToTypeDB(composeRule, address)
@@ -84,10 +87,12 @@ class TextEditorTest: IntegrationTest() {
             writeDataInteractively(composeRule, dbName = testID, DATA_FILE_NAME)
             verifyDataWrite(composeRule, address, dbName = testID, "$testID/$QUERY_FILE_NAME")
         }
+        println("Finishing dataWriteAndCommit.")
     }
 
     @Test
     fun schemaWriteAndRollback() {
+        println("Starting schemaWriteAndRollback.")
         studioTestWithRunner(composeRule) { address ->
             cloneAndOpenProject(composeRule, source = TQL_DATA_PATH, destination = testID)
             connectToTypeDB(composeRule, address)
@@ -111,5 +116,6 @@ class TextEditorTest: IntegrationTest() {
 
             StudioState.client.session.close()
         }
+        println("Finishing schemaWriteAndRollback.")
     }
 }

--- a/test/integration/TextEditorTest.kt
+++ b/test/integration/TextEditorTest.kt
@@ -31,7 +31,7 @@ import com.vaticle.typedb.studio.test.integration.Utils.studioTestWithRunner
 import com.vaticle.typedb.studio.test.integration.Utils.connectToTypeDB
 import com.vaticle.typedb.studio.test.integration.Utils.createDatabase
 import com.vaticle.typedb.studio.test.integration.Utils.cloneAndOpenProject
-import com.vaticle.typedb.studio.test.integration.Utils.wait
+import com.vaticle.typedb.studio.test.integration.Utils.waitAndRecompose
 import com.vaticle.typedb.studio.test.integration.Utils.writeSchemaInteractively
 import com.vaticle.typedb.studio.test.integration.Utils.writeDataInteractively
 import com.vaticle.typedb.studio.test.integration.Utils.verifyDataWrite
@@ -58,14 +58,14 @@ class TextEditorTest: IntegrationTest() {
             val path = cloneAndOpenProject(composeRule, source = SAMPLE_DATA_PATH, destination = testID)
 
             composeRule.onNodeWithText(PLUS_ICON_STRING).performClick()
-            wait(composeRule, Delays.RECOMPOSE)
+            waitAndRecompose(composeRule, Delays.RECOMPOSE)
 
             // This sets saveFileDialog.file!! to the current file, so even though we can't see the window it is useful.
             composeRule.onNodeWithText(SAVE_ICON_STRING).performClick()
             val filePath = File("$path/Untitled1.tql").toPath()
             StudioState.project.saveFileDialog.file!!.trySave(filePath, true)
             StudioState.project.current!!.reloadEntries()
-            wait(composeRule, Delays.FILE_IO)
+            waitAndRecompose(composeRule, Delays.FILE_IO)
 
             assertTrue(File("$path/Untitled1.tql").exists())
         }
@@ -83,7 +83,7 @@ class TextEditorTest: IntegrationTest() {
             StudioState.client.session.tryOpen(database = testID, TypeDBSession.Type.DATA)
 
             composeRule.onNodeWithText(CHEVRON_UP_ICON_STRING).performClick()
-            wait(composeRule, Delays.RECOMPOSE)
+            waitAndRecompose(composeRule, Delays.RECOMPOSE)
 
             // We can assert that the schema has been written successfully here as the schema
             // is shown in the type browser.
@@ -114,7 +114,7 @@ class TextEditorTest: IntegrationTest() {
 
             StudioState.client.session.tryOpen(testID, TypeDBSession.Type.SCHEMA)
 
-            wait(composeRule, Delays.NETWORK_IO)
+            waitAndRecompose(composeRule, Delays.NETWORK_IO)
 
             composeRule.onNodeWithText("schema").performClick()
             composeRule.onNodeWithText("write").performClick()
@@ -122,9 +122,9 @@ class TextEditorTest: IntegrationTest() {
             StudioState.project.current!!.directory.entries.find { it.name == SCHEMA_FILE_NAME }!!.asFile().tryOpen()
 
             composeRule.onNodeWithText(PLAY_ICON_STRING).performClick()
-            wait(composeRule, Delays.NETWORK_IO)
+            waitAndRecompose(composeRule, Delays.NETWORK_IO)
             composeRule.onNodeWithText(ROLLBACK_ICON_STRING).performClick()
-            wait(composeRule, Delays.NETWORK_IO)
+            waitAndRecompose(composeRule, Delays.NETWORK_IO)
 
             composeRule.onNodeWithText("repo-id").assertDoesNotExist()
 

--- a/test/integration/TextEditorTest.kt
+++ b/test/integration/TextEditorTest.kt
@@ -31,7 +31,7 @@ import com.vaticle.typedb.studio.test.integration.Utils.studioTestWithRunner
 import com.vaticle.typedb.studio.test.integration.Utils.connectToTypeDB
 import com.vaticle.typedb.studio.test.integration.Utils.createDatabase
 import com.vaticle.typedb.studio.test.integration.Utils.cloneAndOpenProject
-import com.vaticle.typedb.studio.test.integration.Utils.waitAndRecompose
+import com.vaticle.typedb.studio.test.integration.Utils.delayAndRecompose
 import com.vaticle.typedb.studio.test.integration.Utils.writeSchemaInteractively
 import com.vaticle.typedb.studio.test.integration.Utils.writeDataInteractively
 import com.vaticle.typedb.studio.test.integration.Utils.verifyDataWrite
@@ -58,14 +58,14 @@ class TextEditorTest: IntegrationTest() {
             val path = cloneAndOpenProject(composeRule, source = SAMPLE_DATA_PATH, destination = testID)
 
             composeRule.onNodeWithText(PLUS_ICON_STRING).performClick()
-            waitAndRecompose(composeRule, Delays.RECOMPOSE)
+            delayAndRecompose(composeRule)
 
             // This sets saveFileDialog.file!! to the current file, so even though we can't see the window it is useful.
             composeRule.onNodeWithText(SAVE_ICON_STRING).performClick()
             val filePath = File("$path/Untitled1.tql").toPath()
             StudioState.project.saveFileDialog.file!!.trySave(filePath, true)
             StudioState.project.current!!.reloadEntries()
-            waitAndRecompose(composeRule, Delays.FILE_IO)
+            delayAndRecompose(composeRule, Delays.FILE_IO)
 
             assertTrue(File("$path/Untitled1.tql").exists())
         }
@@ -83,7 +83,7 @@ class TextEditorTest: IntegrationTest() {
             StudioState.client.session.tryOpen(database = testID, TypeDBSession.Type.DATA)
 
             composeRule.onNodeWithText(CHEVRON_UP_ICON_STRING).performClick()
-            waitAndRecompose(composeRule, Delays.RECOMPOSE)
+            delayAndRecompose(composeRule)
 
             // We can assert that the schema has been written successfully here as the schema
             // is shown in the type browser.
@@ -114,7 +114,7 @@ class TextEditorTest: IntegrationTest() {
 
             StudioState.client.session.tryOpen(testID, TypeDBSession.Type.SCHEMA)
 
-            waitAndRecompose(composeRule, Delays.NETWORK_IO)
+            delayAndRecompose(composeRule, Delays.NETWORK_IO)
 
             composeRule.onNodeWithText("schema").performClick()
             composeRule.onNodeWithText("write").performClick()
@@ -122,9 +122,9 @@ class TextEditorTest: IntegrationTest() {
             StudioState.project.current!!.directory.entries.find { it.name == SCHEMA_FILE_NAME }!!.asFile().tryOpen()
 
             composeRule.onNodeWithText(PLAY_ICON_STRING).performClick()
-            waitAndRecompose(composeRule, Delays.NETWORK_IO)
+            delayAndRecompose(composeRule, Delays.NETWORK_IO)
             composeRule.onNodeWithText(ROLLBACK_ICON_STRING).performClick()
-            waitAndRecompose(composeRule, Delays.NETWORK_IO)
+            delayAndRecompose(composeRule, Delays.NETWORK_IO)
 
             composeRule.onNodeWithText("repo-id").assertDoesNotExist()
 

--- a/test/integration/TextEditorTest.kt
+++ b/test/integration/TextEditorTest.kt
@@ -35,7 +35,7 @@ class TextEditorTest: IntegrationTest() {
     @Test
     fun makeAFileAndSaveIt() {
         studioTest(composeRule) {
-            // We have to open a project to enable the '+' to create a new file.
+        // We have to open a project to enable the '+' to create a new file.
             val path = cloneAndOpenProject(composeRule, source = SAMPLE_DATA_PATH, destination = testID)
 
             composeRule.onNodeWithText(PLUS_ICON_STRING).performClick()
@@ -54,8 +54,8 @@ class TextEditorTest: IntegrationTest() {
 
     @Test
     fun schemaWriteAndCommit() {
-        studioTest(composeRule) {
-            // We have to open a project to enable the '+' to create a new file.
+        studioTestWithRunner(composeRule) { address ->
+        // We have to open a project to enable the '+' to create a new file.
             cloneAndOpenProject(composeRule, source = TQL_DATA_PATH, destination = testID)
             connectToTypeDB(composeRule, address)
             createDatabase(composeRule, dbName = testID)
@@ -76,8 +76,8 @@ class TextEditorTest: IntegrationTest() {
 
     @Test
     fun dataWriteAndCommit() {
-        studioTest(composeRule) {
-            cloneAndOpenProject(composeRule, source = TQL_DATA_PATH, destination = testID)
+        studioTestWithRunner(composeRule) { address ->
+        cloneAndOpenProject(composeRule, source = TQL_DATA_PATH, destination = testID)
             connectToTypeDB(composeRule, address)
             createDatabase(composeRule, dbName = testID)
             writeSchemaInteractively(composeRule, dbName = testID, SCHEMA_FILE_NAME)
@@ -88,7 +88,7 @@ class TextEditorTest: IntegrationTest() {
 
     @Test
     fun schemaWriteAndRollback() {
-        studioTest(composeRule) {
+        studioTestWithRunner(composeRule) { address ->
             cloneAndOpenProject(composeRule, source = TQL_DATA_PATH, destination = testID)
             connectToTypeDB(composeRule, address)
             createDatabase(composeRule, dbName = testID)

--- a/test/integration/TextEditorTest.kt
+++ b/test/integration/TextEditorTest.kt
@@ -35,6 +35,16 @@ import com.vaticle.typedb.studio.test.integration.Utils.wait
 import com.vaticle.typedb.studio.test.integration.Utils.writeSchemaInteractively
 import com.vaticle.typedb.studio.test.integration.Utils.writeDataInteractively
 import com.vaticle.typedb.studio.test.integration.Utils.verifyDataWrite
+import com.vaticle.typedb.studio.test.integration.Utils.SCHEMA_FILE_NAME
+import com.vaticle.typedb.studio.test.integration.Utils.DATA_FILE_NAME
+import com.vaticle.typedb.studio.test.integration.Utils.QUERY_FILE_NAME
+import com.vaticle.typedb.studio.test.integration.Utils.TQL_DATA_PATH
+import com.vaticle.typedb.studio.test.integration.Utils.SAVE_ICON_STRING
+import com.vaticle.typedb.studio.test.integration.Utils.PLAY_ICON_STRING
+import com.vaticle.typedb.studio.test.integration.Utils.ROLLBACK_ICON_STRING
+import com.vaticle.typedb.studio.test.integration.Utils.PLUS_ICON_STRING
+import com.vaticle.typedb.studio.test.integration.Utils.SAMPLE_DATA_PATH
+import com.vaticle.typedb.studio.test.integration.Utils.CHEVRON_UP_ICON_STRING
 import java.io.File
 import kotlin.test.assertTrue
 import org.junit.Test
@@ -45,17 +55,17 @@ class TextEditorTest: IntegrationTest() {
     fun makeAFileAndSaveIt() {
         studioTest(composeRule) {
         // We have to open a project to enable the '+' to create a new file.
-            val path = cloneAndOpenProject(composeRule, source = Utils.SAMPLE_DATA_PATH, destination = testID)
+            val path = cloneAndOpenProject(composeRule, source = SAMPLE_DATA_PATH, destination = testID)
 
-            composeRule.onNodeWithText(Utils.PLUS_ICON_STRING).performClick()
-            wait(composeRule, 750)
+            composeRule.onNodeWithText(PLUS_ICON_STRING).performClick()
+            wait(composeRule, Delays.RECOMPOSE)
 
             // This sets saveFileDialog.file!! to the current file, so even though we can't see the window it is useful.
-            composeRule.onNodeWithText(Utils.SAVE_ICON_STRING).performClick()
+            composeRule.onNodeWithText(SAVE_ICON_STRING).performClick()
             val filePath = File("$path/Untitled1.tql").toPath()
             StudioState.project.saveFileDialog.file!!.trySave(filePath, true)
             StudioState.project.current!!.reloadEntries()
-            wait(composeRule, 750)
+            wait(composeRule, Delays.FILE_IO)
 
             assertTrue(File("$path/Untitled1.tql").exists())
         }
@@ -65,15 +75,15 @@ class TextEditorTest: IntegrationTest() {
     fun schemaWriteAndCommit() {
         studioTestWithRunner(composeRule) { address ->
         // We have to open a project to enable the '+' to create a new file.
-            cloneAndOpenProject(composeRule, source = Utils.TQL_DATA_PATH, destination = testID)
+            cloneAndOpenProject(composeRule, source = TQL_DATA_PATH, destination = testID)
             connectToTypeDB(composeRule, address)
             createDatabase(composeRule, dbName = testID)
-            writeSchemaInteractively(composeRule, dbName = testID, Utils.SCHEMA_FILE_NAME)
+            writeSchemaInteractively(composeRule, dbName = testID, SCHEMA_FILE_NAME)
 
             StudioState.client.session.tryOpen(database = testID, TypeDBSession.Type.DATA)
 
-            composeRule.onNodeWithText(Utils.CHEVRON_UP_ICON_STRING).performClick()
-            wait(composeRule, 750)
+            composeRule.onNodeWithText(CHEVRON_UP_ICON_STRING).performClick()
+            wait(composeRule, Delays.RECOMPOSE)
 
             // We can assert that the schema has been written successfully here as the schema
             // is shown in the type browser.
@@ -86,35 +96,35 @@ class TextEditorTest: IntegrationTest() {
     @Test
     fun dataWriteAndCommit() {
         studioTestWithRunner(composeRule) { address ->
-        cloneAndOpenProject(composeRule, source = Utils.TQL_DATA_PATH, destination = testID)
+        cloneAndOpenProject(composeRule, source = TQL_DATA_PATH, destination = testID)
             connectToTypeDB(composeRule, address)
             createDatabase(composeRule, dbName = testID)
-            writeSchemaInteractively(composeRule, dbName = testID, Utils.SCHEMA_FILE_NAME)
-            writeDataInteractively(composeRule, dbName = testID, Utils.DATA_FILE_NAME)
-            verifyDataWrite(composeRule, address, dbName = testID, "$testID/${Utils.QUERY_FILE_NAME}")
+            writeSchemaInteractively(composeRule, dbName = testID, SCHEMA_FILE_NAME)
+            writeDataInteractively(composeRule, dbName = testID, DATA_FILE_NAME)
+            verifyDataWrite(composeRule, address, dbName = testID, "$testID/${QUERY_FILE_NAME}")
         }
     }
 
     @Test
     fun schemaWriteAndRollback() {
         studioTestWithRunner(composeRule) { address ->
-            cloneAndOpenProject(composeRule, source = Utils.TQL_DATA_PATH, destination = testID)
+            cloneAndOpenProject(composeRule, source = TQL_DATA_PATH, destination = testID)
             connectToTypeDB(composeRule, address)
             createDatabase(composeRule, dbName = testID)
 
             StudioState.client.session.tryOpen(testID, TypeDBSession.Type.SCHEMA)
 
-            wait(composeRule, 750)
+            wait(composeRule, Delays.NETWORK_IO)
 
             composeRule.onNodeWithText("schema").performClick()
             composeRule.onNodeWithText("write").performClick()
 
-            StudioState.project.current!!.directory.entries.find { it.name == Utils.SCHEMA_FILE_NAME }!!.asFile().tryOpen()
+            StudioState.project.current!!.directory.entries.find { it.name == SCHEMA_FILE_NAME }!!.asFile().tryOpen()
 
-            composeRule.onNodeWithText(Utils.PLAY_ICON_STRING).performClick()
-            wait(composeRule, 750)
-            composeRule.onNodeWithText(Utils.ROLLBACK_ICON_STRING).performClick()
-            wait(composeRule, 750)
+            composeRule.onNodeWithText(PLAY_ICON_STRING).performClick()
+            wait(composeRule, Delays.NETWORK_IO)
+            composeRule.onNodeWithText(ROLLBACK_ICON_STRING).performClick()
+            wait(composeRule, Delays.NETWORK_IO)
 
             composeRule.onNodeWithText("repo-id").assertDoesNotExist()
 

--- a/test/integration/TextEditorTest.kt
+++ b/test/integration/TextEditorTest.kt
@@ -62,12 +62,12 @@ class TextEditorTest: IntegrationTest() {
 
             // This sets saveFileDialog.file!! to the current file, so even though we can't see the window it is useful.
             composeRule.onNodeWithText(SAVE_ICON_STRING).performClick()
-            val filePath = File("$path/Untitled1.tql").toPath()
-            StudioState.project.saveFileDialog.file!!.trySave(filePath, true)
+            val file = File("$path/Untitled1.tql")
+            StudioState.project.saveFileDialog.file!!.trySave(file.toPath(), true)
             StudioState.project.current!!.reloadEntries()
             delayAndRecompose(composeRule, Delays.FILE_IO)
 
-            assertTrue(File("$path/Untitled1.tql").exists())
+            assertTrue(file.exists())
         }
     }
 
@@ -89,8 +89,6 @@ class TextEditorTest: IntegrationTest() {
             // We can assert that the schema has been written successfully here as the schema
             // is shown in the type browser.
             composeRule.onNodeWithText("commit-date").assertExists()
-
-            StudioState.client.session.close()
         }
     }
 
@@ -127,8 +125,6 @@ class TextEditorTest: IntegrationTest() {
             delayAndRecompose(composeRule, Delays.NETWORK_IO)
 
             composeRule.onNodeWithText("repo-id").assertDoesNotExist()
-
-            StudioState.client.session.close()
         }
     }
 }

--- a/test/integration/TextEditorTest.kt
+++ b/test/integration/TextEditorTest.kt
@@ -48,14 +48,14 @@ class TextEditorTest: IntegrationTest() {
             val path = cloneAndOpenProject(composeRule, source = Utils.SAMPLE_DATA_PATH, destination = testID)
 
             composeRule.onNodeWithText(Utils.PLUS_ICON_STRING).performClick()
-            wait(composeRule, 500)
+            wait(composeRule, 750)
 
             // This sets saveFileDialog.file!! to the current file, so even though we can't see the window it is useful.
             composeRule.onNodeWithText(Utils.SAVE_ICON_STRING).performClick()
             val filePath = File("$path/Untitled1.tql").toPath()
             StudioState.project.saveFileDialog.file!!.trySave(filePath, true)
             StudioState.project.current!!.reloadEntries()
-            wait(composeRule, 500)
+            wait(composeRule, 750)
 
             assertTrue(File("$path/Untitled1.tql").exists())
         }
@@ -74,7 +74,7 @@ class TextEditorTest: IntegrationTest() {
             StudioState.client.session.tryOpen(database = testID, TypeDBSession.Type.DATA)
 
             composeRule.onNodeWithText(Utils.CHEVRON_UP_ICON_STRING).performClick()
-            wait(composeRule, 500)
+            wait(composeRule, 750)
 
             // We can assert that the schema has been written successfully here as the schema
             // is shown in the type browser.
@@ -109,7 +109,7 @@ class TextEditorTest: IntegrationTest() {
 
             StudioState.client.session.tryOpen(testID, TypeDBSession.Type.SCHEMA)
 
-            wait(composeRule, 500)
+            wait(composeRule, 750)
 
             composeRule.onNodeWithText("schema").performClick()
             composeRule.onNodeWithText("write").performClick()
@@ -117,9 +117,9 @@ class TextEditorTest: IntegrationTest() {
             StudioState.project.current!!.directory.entries.find { it.name == Utils.SCHEMA_FILE_NAME }!!.asFile().tryOpen()
 
             composeRule.onNodeWithText(Utils.PLAY_ICON_STRING).performClick()
-            wait(composeRule, 500)
+            wait(composeRule, 750)
             composeRule.onNodeWithText(Utils.ROLLBACK_ICON_STRING).performClick()
-            wait(composeRule, 500)
+            wait(composeRule, 750)
 
             composeRule.onNodeWithText("repo-id").assertDoesNotExist()
 

--- a/test/integration/TextEditorTest.kt
+++ b/test/integration/TextEditorTest.kt
@@ -81,6 +81,7 @@ class TextEditorTest: IntegrationTest() {
             writeSchemaInteractively(composeRule, dbName = testID, SCHEMA_FILE_NAME)
 
             StudioState.client.session.tryOpen(database = testID, TypeDBSession.Type.DATA)
+            delayAndRecompose(composeRule, Delays.NETWORK_IO)
 
             composeRule.onNodeWithText(CHEVRON_UP_ICON_STRING).performClick()
             delayAndRecompose(composeRule)
@@ -113,7 +114,6 @@ class TextEditorTest: IntegrationTest() {
             createDatabase(composeRule, dbName = testID)
 
             StudioState.client.session.tryOpen(testID, TypeDBSession.Type.SCHEMA)
-
             delayAndRecompose(composeRule, Delays.NETWORK_IO)
 
             composeRule.onNodeWithText("schema").performClick()

--- a/test/integration/TypeBrowserTest.kt
+++ b/test/integration/TypeBrowserTest.kt
@@ -40,7 +40,6 @@ class TypeBrowserTest: IntegrationTest() {
 
     @Test
     fun interactiveSchemaWritesAutomaticallyDisplayed() {
-        println("Starting interactiveSchemaWritesAutomaticallyDisplayed.")
         studioTestWithRunner(composeRule) { address ->
             connectToTypeDB(composeRule, address)
             cloneAndOpenProject(composeRule, source = Utils.TQL_DATA_PATH, destination = testID)
@@ -53,12 +52,10 @@ class TypeBrowserTest: IntegrationTest() {
             composeRule.onNodeWithText("commit-date").assertExists()
             composeRule.onNodeWithText("commit-hash").assertExists()
         }
-        println("Finishing interactiveSchemaWritesAutomaticallyDisplayed.")
     }
 
     @Test
     fun collapseTypes() {
-        println("Starting collapseTypes.")
         studioTestWithRunner(composeRule) { address ->
             connectToTypeDB(composeRule, address)
             cloneAndOpenProject(composeRule, source = Utils.TQL_DATA_PATH, destination = testID)
@@ -78,12 +75,10 @@ class TypeBrowserTest: IntegrationTest() {
 
             StudioState.client.session.close()
         }
-        println("Finishing collapseTypes.")
     }
 
     @Test
     fun collapseThenExpandTypes() {
-        println("Starting collapseThenExpandTypes.")
         studioTestWithRunner(composeRule) { address ->
             connectToTypeDB(composeRule, address)
             cloneAndOpenProject(composeRule, source = Utils.TQL_DATA_PATH, destination = testID)
@@ -104,7 +99,6 @@ class TypeBrowserTest: IntegrationTest() {
 
             StudioState.client.session.close()
         }
-        println("Finishing collapseThenExpandTypes.")
     }
 
     // This test is ignored as the export schema button doesn't open a new file during testing.

--- a/test/integration/TypeBrowserTest.kt
+++ b/test/integration/TypeBrowserTest.kt
@@ -69,10 +69,10 @@ class TypeBrowserTest: IntegrationTest() {
 
             composeRule.onAllNodesWithText("Project").get(0).performClick()
             composeRule.onAllNodesWithText("Project").get(1).performClick()
-            wait(composeRule, 500)
+            wait(composeRule, 750)
 
             composeRule.onNodeWithText(Utils.DOUBLE_CHEVRON_UP_ICON_STRING).performClick()
-            wait(composeRule, 500)
+            wait(composeRule, 750)
 
             composeRule.onNodeWithText("commit-date").assertDoesNotExist()
 
@@ -93,12 +93,12 @@ class TypeBrowserTest: IntegrationTest() {
             StudioState.client.session.tryOpen(database = testID, TypeDBSession.Type.DATA)
 
             composeRule.onNodeWithText(Utils.DOUBLE_CHEVRON_UP_ICON_STRING).performClick()
-            wait(composeRule, 500)
+            wait(composeRule, 750)
 
             composeRule.onNodeWithText("commit-date").assertDoesNotExist()
 
             composeRule.onNodeWithText(Utils.DOUBLE_CHEVRON_DOWN_ICON_STRING).performClick()
-            wait(composeRule, 500)
+            wait(composeRule, 750)
 
             composeRule.onNodeWithText("commit-date").assertExists()
 

--- a/test/integration/TypeBrowserTest.kt
+++ b/test/integration/TypeBrowserTest.kt
@@ -31,7 +31,7 @@ import com.vaticle.typedb.studio.test.integration.Utils.studioTestWithRunner
 import com.vaticle.typedb.studio.test.integration.Utils.connectToTypeDB
 import com.vaticle.typedb.studio.test.integration.Utils.createDatabase
 import com.vaticle.typedb.studio.test.integration.Utils.cloneAndOpenProject
-import com.vaticle.typedb.studio.test.integration.Utils.wait
+import com.vaticle.typedb.studio.test.integration.Utils.waitAndRecompose
 import com.vaticle.typedb.studio.test.integration.Utils.writeSchemaInteractively
 import com.vaticle.typedb.studio.test.integration.Utils.SCHEMA_FILE_NAME
 import com.vaticle.typedb.studio.test.integration.Utils.TQL_DATA_PATH
@@ -70,10 +70,10 @@ class TypeBrowserTest: IntegrationTest() {
 
             composeRule.onAllNodesWithText("Project").get(0).performClick()
             composeRule.onAllNodesWithText("Project").get(1).performClick()
-            wait(composeRule, Delays.RECOMPOSE)
+            waitAndRecompose(composeRule, Delays.RECOMPOSE)
 
             composeRule.onNodeWithText(DOUBLE_CHEVRON_UP_ICON_STRING).performClick()
-            wait(composeRule, Delays.RECOMPOSE)
+            waitAndRecompose(composeRule, Delays.RECOMPOSE)
 
             composeRule.onNodeWithText("commit-date").assertDoesNotExist()
 
@@ -92,12 +92,12 @@ class TypeBrowserTest: IntegrationTest() {
             StudioState.client.session.tryOpen(database = testID, TypeDBSession.Type.DATA)
 
             composeRule.onNodeWithText(DOUBLE_CHEVRON_UP_ICON_STRING).performClick()
-            wait(composeRule, Delays.RECOMPOSE)
+            waitAndRecompose(composeRule, Delays.RECOMPOSE)
 
             composeRule.onNodeWithText("commit-date").assertDoesNotExist()
 
             composeRule.onNodeWithText(DOUBLE_CHEVRON_DOWN_ICON_STRING).performClick()
-            wait(composeRule, Delays.RECOMPOSE)
+            waitAndRecompose(composeRule, Delays.RECOMPOSE)
 
             composeRule.onNodeWithText("commit-date").assertExists()
 

--- a/test/integration/TypeBrowserTest.kt
+++ b/test/integration/TypeBrowserTest.kt
@@ -34,7 +34,7 @@ class TypeBrowserTest: IntegrationTest() {
 
     @Test
     fun interactiveSchemaWritesAutomaticallyDisplayed() {
-        studioTest(composeRule) {
+        studioTestWithRunner(composeRule) { address ->
             connectToTypeDB(composeRule, address)
             cloneAndOpenProject(composeRule, source = TQL_DATA_PATH, destination = testID)
             createDatabase(composeRule, dbName = testID)
@@ -50,7 +50,7 @@ class TypeBrowserTest: IntegrationTest() {
 
     @Test
     fun collapseTypes() {
-        studioTest(composeRule) {
+        studioTestWithRunner(composeRule) { address ->
             connectToTypeDB(composeRule, address)
             cloneAndOpenProject(composeRule, source = TQL_DATA_PATH, destination = testID)
             createDatabase(composeRule, dbName = testID)
@@ -73,7 +73,7 @@ class TypeBrowserTest: IntegrationTest() {
 
     @Test
     fun collapseThenExpandTypes() {
-        studioTest(composeRule) {
+        studioTestWithRunner(composeRule) { address ->
             connectToTypeDB(composeRule, address)
             cloneAndOpenProject(composeRule, source = TQL_DATA_PATH, destination = testID)
             createDatabase(composeRule, dbName = testID)
@@ -99,7 +99,7 @@ class TypeBrowserTest: IntegrationTest() {
     @Ignore
     @Test
     fun exportSchema() {
-        studioTest(composeRule) {
+        studioTestWithRunner(composeRule) { address ->
             connectToTypeDB(composeRule, address)
             cloneAndOpenProject(composeRule, source = TQL_DATA_PATH, destination = testID)
             createDatabase(composeRule, dbName = testID)

--- a/test/integration/TypeBrowserTest.kt
+++ b/test/integration/TypeBrowserTest.kt
@@ -34,6 +34,7 @@ class TypeBrowserTest: IntegrationTest() {
 
     @Test
     fun interactiveSchemaWritesAutomaticallyDisplayed() {
+        println("Starting interactiveSchemaWritesAutomaticallyDisplayed.")
         studioTestWithRunner(composeRule) { address ->
             connectToTypeDB(composeRule, address)
             cloneAndOpenProject(composeRule, source = TQL_DATA_PATH, destination = testID)
@@ -46,10 +47,12 @@ class TypeBrowserTest: IntegrationTest() {
             composeRule.onNodeWithText("commit-date").assertExists()
             composeRule.onNodeWithText("commit-hash").assertExists()
         }
+        println("Finishing interactiveSchemaWritesAutomaticallyDisplayed.")
     }
 
     @Test
     fun collapseTypes() {
+        println("Starting collapseTypes.")
         studioTestWithRunner(composeRule) { address ->
             connectToTypeDB(composeRule, address)
             cloneAndOpenProject(composeRule, source = TQL_DATA_PATH, destination = testID)
@@ -69,10 +72,12 @@ class TypeBrowserTest: IntegrationTest() {
 
             StudioState.client.session.close()
         }
+        println("Finishing collapseTypes.")
     }
 
     @Test
     fun collapseThenExpandTypes() {
+        println("Starting collapseThenExpandTypes.")
         studioTestWithRunner(composeRule) { address ->
             connectToTypeDB(composeRule, address)
             cloneAndOpenProject(composeRule, source = TQL_DATA_PATH, destination = testID)
@@ -93,6 +98,7 @@ class TypeBrowserTest: IntegrationTest() {
 
             StudioState.client.session.close()
         }
+        println("Finishing collapseThenExpandTypes.")
     }
 
     // This test is ignored as the export schema button doesn't open a new file during testing.

--- a/test/integration/TypeBrowserTest.kt
+++ b/test/integration/TypeBrowserTest.kt
@@ -33,6 +33,10 @@ import com.vaticle.typedb.studio.test.integration.Utils.createDatabase
 import com.vaticle.typedb.studio.test.integration.Utils.cloneAndOpenProject
 import com.vaticle.typedb.studio.test.integration.Utils.wait
 import com.vaticle.typedb.studio.test.integration.Utils.writeSchemaInteractively
+import com.vaticle.typedb.studio.test.integration.Utils.SCHEMA_FILE_NAME
+import com.vaticle.typedb.studio.test.integration.Utils.TQL_DATA_PATH
+import com.vaticle.typedb.studio.test.integration.Utils.DOUBLE_CHEVRON_DOWN_ICON_STRING
+import com.vaticle.typedb.studio.test.integration.Utils.DOUBLE_CHEVRON_UP_ICON_STRING
 import org.junit.Ignore
 import org.junit.Test
 
@@ -42,9 +46,9 @@ class TypeBrowserTest: IntegrationTest() {
     fun interactiveSchemaWritesAutomaticallyDisplayed() {
         studioTestWithRunner(composeRule) { address ->
             connectToTypeDB(composeRule, address)
-            cloneAndOpenProject(composeRule, source = Utils.TQL_DATA_PATH, destination = testID)
+            cloneAndOpenProject(composeRule, source = TQL_DATA_PATH, destination = testID)
             createDatabase(composeRule, dbName = testID)
-            writeSchemaInteractively(composeRule, dbName = testID, Utils.SCHEMA_FILE_NAME)
+            writeSchemaInteractively(composeRule, dbName = testID, SCHEMA_FILE_NAME)
 
             // We can assert that the schema has been written successfully here as the schema
             // is shown in the type browser.
@@ -58,18 +62,18 @@ class TypeBrowserTest: IntegrationTest() {
     fun collapseTypes() {
         studioTestWithRunner(composeRule) { address ->
             connectToTypeDB(composeRule, address)
-            cloneAndOpenProject(composeRule, source = Utils.TQL_DATA_PATH, destination = testID)
+            cloneAndOpenProject(composeRule, source = TQL_DATA_PATH, destination = testID)
             createDatabase(composeRule, dbName = testID)
-            writeSchemaInteractively(composeRule, dbName = testID, Utils.SCHEMA_FILE_NAME)
+            writeSchemaInteractively(composeRule, dbName = testID, SCHEMA_FILE_NAME)
 
             StudioState.client.session.tryOpen(database = testID, TypeDBSession.Type.DATA)
 
             composeRule.onAllNodesWithText("Project").get(0).performClick()
             composeRule.onAllNodesWithText("Project").get(1).performClick()
-            wait(composeRule, 750)
+            wait(composeRule, Delays.RECOMPOSE)
 
-            composeRule.onNodeWithText(Utils.DOUBLE_CHEVRON_UP_ICON_STRING).performClick()
-            wait(composeRule, 750)
+            composeRule.onNodeWithText(DOUBLE_CHEVRON_UP_ICON_STRING).performClick()
+            wait(composeRule, Delays.RECOMPOSE)
 
             composeRule.onNodeWithText("commit-date").assertDoesNotExist()
 
@@ -81,19 +85,19 @@ class TypeBrowserTest: IntegrationTest() {
     fun collapseThenExpandTypes() {
         studioTestWithRunner(composeRule) { address ->
             connectToTypeDB(composeRule, address)
-            cloneAndOpenProject(composeRule, source = Utils.TQL_DATA_PATH, destination = testID)
+            cloneAndOpenProject(composeRule, source = TQL_DATA_PATH, destination = testID)
             createDatabase(composeRule, dbName = testID)
-            writeSchemaInteractively(composeRule, dbName = testID, Utils.SCHEMA_FILE_NAME)
+            writeSchemaInteractively(composeRule, dbName = testID, SCHEMA_FILE_NAME)
 
             StudioState.client.session.tryOpen(database = testID, TypeDBSession.Type.DATA)
 
-            composeRule.onNodeWithText(Utils.DOUBLE_CHEVRON_UP_ICON_STRING).performClick()
-            wait(composeRule, 750)
+            composeRule.onNodeWithText(DOUBLE_CHEVRON_UP_ICON_STRING).performClick()
+            wait(composeRule, Delays.RECOMPOSE)
 
             composeRule.onNodeWithText("commit-date").assertDoesNotExist()
 
-            composeRule.onNodeWithText(Utils.DOUBLE_CHEVRON_DOWN_ICON_STRING).performClick()
-            wait(composeRule, 750)
+            composeRule.onNodeWithText(DOUBLE_CHEVRON_DOWN_ICON_STRING).performClick()
+            wait(composeRule, Delays.RECOMPOSE)
 
             composeRule.onNodeWithText("commit-date").assertExists()
 
@@ -107,9 +111,9 @@ class TypeBrowserTest: IntegrationTest() {
     fun exportSchema() {
         studioTestWithRunner(composeRule) { address ->
             connectToTypeDB(composeRule, address)
-            cloneAndOpenProject(composeRule, source = Utils.TQL_DATA_PATH, destination = testID)
+            cloneAndOpenProject(composeRule, source = TQL_DATA_PATH, destination = testID)
             createDatabase(composeRule, dbName = testID)
-            writeSchemaInteractively(composeRule, dbName = testID, Utils.SCHEMA_FILE_NAME)
+            writeSchemaInteractively(composeRule, dbName = testID, SCHEMA_FILE_NAME)
 
             StudioState.client.session.tryOpen(database = testID, TypeDBSession.Type.DATA)
 

--- a/test/integration/TypeBrowserTest.kt
+++ b/test/integration/TypeBrowserTest.kt
@@ -31,7 +31,7 @@ import com.vaticle.typedb.studio.test.integration.Utils.studioTestWithRunner
 import com.vaticle.typedb.studio.test.integration.Utils.connectToTypeDB
 import com.vaticle.typedb.studio.test.integration.Utils.createDatabase
 import com.vaticle.typedb.studio.test.integration.Utils.cloneAndOpenProject
-import com.vaticle.typedb.studio.test.integration.Utils.waitAndRecompose
+import com.vaticle.typedb.studio.test.integration.Utils.delayAndRecompose
 import com.vaticle.typedb.studio.test.integration.Utils.writeSchemaInteractively
 import com.vaticle.typedb.studio.test.integration.Utils.SCHEMA_FILE_NAME
 import com.vaticle.typedb.studio.test.integration.Utils.TQL_DATA_PATH
@@ -70,10 +70,10 @@ class TypeBrowserTest: IntegrationTest() {
 
             composeRule.onAllNodesWithText("Project").get(0).performClick()
             composeRule.onAllNodesWithText("Project").get(1).performClick()
-            waitAndRecompose(composeRule, Delays.RECOMPOSE)
+            delayAndRecompose(composeRule)
 
             composeRule.onNodeWithText(DOUBLE_CHEVRON_UP_ICON_STRING).performClick()
-            waitAndRecompose(composeRule, Delays.RECOMPOSE)
+            delayAndRecompose(composeRule)
 
             composeRule.onNodeWithText("commit-date").assertDoesNotExist()
 
@@ -92,12 +92,12 @@ class TypeBrowserTest: IntegrationTest() {
             StudioState.client.session.tryOpen(database = testID, TypeDBSession.Type.DATA)
 
             composeRule.onNodeWithText(DOUBLE_CHEVRON_UP_ICON_STRING).performClick()
-            waitAndRecompose(composeRule, Delays.RECOMPOSE)
+            delayAndRecompose(composeRule)
 
             composeRule.onNodeWithText("commit-date").assertDoesNotExist()
 
             composeRule.onNodeWithText(DOUBLE_CHEVRON_DOWN_ICON_STRING).performClick()
-            waitAndRecompose(composeRule, Delays.RECOMPOSE)
+            delayAndRecompose(composeRule)
 
             composeRule.onNodeWithText("commit-date").assertExists()
 

--- a/test/integration/TypeBrowserTest.kt
+++ b/test/integration/TypeBrowserTest.kt
@@ -67,6 +67,7 @@ class TypeBrowserTest: IntegrationTest() {
             writeSchemaInteractively(composeRule, dbName = testID, SCHEMA_FILE_NAME)
 
             StudioState.client.session.tryOpen(database = testID, TypeDBSession.Type.DATA)
+            delayAndRecompose(composeRule, Delays.NETWORK_IO)
 
             composeRule.onAllNodesWithText("Project").get(0).performClick()
             composeRule.onAllNodesWithText("Project").get(1).performClick()
@@ -116,6 +117,7 @@ class TypeBrowserTest: IntegrationTest() {
             writeSchemaInteractively(composeRule, dbName = testID, SCHEMA_FILE_NAME)
 
             StudioState.client.session.tryOpen(database = testID, TypeDBSession.Type.DATA)
+            delayAndRecompose(composeRule, Delays.NETWORK_IO)
 
             StudioState.schema.exportTypeSchema { schema ->
                 StudioState.project.current!!.reloadEntries()

--- a/test/integration/TypeBrowserTest.kt
+++ b/test/integration/TypeBrowserTest.kt
@@ -35,7 +35,7 @@ class TypeBrowserTest: IntegrationTest() {
     @Test
     fun interactiveSchemaWritesAutomaticallyDisplayed() {
         studioTest(composeRule) {
-            connectToTypeDB(composeRule, DB_ADDRESS)
+            connectToTypeDB(composeRule, address)
             cloneAndOpenProject(composeRule, source = TQL_DATA_PATH, destination = testID)
             createDatabase(composeRule, dbName = testID)
             writeSchemaInteractively(composeRule, dbName = testID, SCHEMA_FILE_NAME)
@@ -51,7 +51,7 @@ class TypeBrowserTest: IntegrationTest() {
     @Test
     fun collapseTypes() {
         studioTest(composeRule) {
-            connectToTypeDB(composeRule, DB_ADDRESS)
+            connectToTypeDB(composeRule, address)
             cloneAndOpenProject(composeRule, source = TQL_DATA_PATH, destination = testID)
             createDatabase(composeRule, dbName = testID)
             writeSchemaInteractively(composeRule, dbName = testID, SCHEMA_FILE_NAME)
@@ -74,7 +74,7 @@ class TypeBrowserTest: IntegrationTest() {
     @Test
     fun collapseThenExpandTypes() {
         studioTest(composeRule) {
-            connectToTypeDB(composeRule, DB_ADDRESS)
+            connectToTypeDB(composeRule, address)
             cloneAndOpenProject(composeRule, source = TQL_DATA_PATH, destination = testID)
             createDatabase(composeRule, dbName = testID)
             writeSchemaInteractively(composeRule, dbName = testID, SCHEMA_FILE_NAME)
@@ -100,7 +100,7 @@ class TypeBrowserTest: IntegrationTest() {
     @Test
     fun exportSchema() {
         studioTest(composeRule) {
-            connectToTypeDB(composeRule, DB_ADDRESS)
+            connectToTypeDB(composeRule, address)
             cloneAndOpenProject(composeRule, source = TQL_DATA_PATH, destination = testID)
             createDatabase(composeRule, dbName = testID)
             writeSchemaInteractively(composeRule, dbName = testID, SCHEMA_FILE_NAME)

--- a/test/integration/TypeBrowserTest.kt
+++ b/test/integration/TypeBrowserTest.kt
@@ -27,6 +27,12 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.vaticle.typedb.client.api.TypeDBSession
 import com.vaticle.typedb.studio.state.StudioState
+import com.vaticle.typedb.studio.test.integration.Utils.studioTestWithRunner
+import com.vaticle.typedb.studio.test.integration.Utils.connectToTypeDB
+import com.vaticle.typedb.studio.test.integration.Utils.createDatabase
+import com.vaticle.typedb.studio.test.integration.Utils.cloneAndOpenProject
+import com.vaticle.typedb.studio.test.integration.Utils.wait
+import com.vaticle.typedb.studio.test.integration.Utils.writeSchemaInteractively
 import org.junit.Ignore
 import org.junit.Test
 
@@ -37,9 +43,9 @@ class TypeBrowserTest: IntegrationTest() {
         println("Starting interactiveSchemaWritesAutomaticallyDisplayed.")
         studioTestWithRunner(composeRule) { address ->
             connectToTypeDB(composeRule, address)
-            cloneAndOpenProject(composeRule, source = TQL_DATA_PATH, destination = testID)
+            cloneAndOpenProject(composeRule, source = Utils.TQL_DATA_PATH, destination = testID)
             createDatabase(composeRule, dbName = testID)
-            writeSchemaInteractively(composeRule, dbName = testID, SCHEMA_FILE_NAME)
+            writeSchemaInteractively(composeRule, dbName = testID, Utils.SCHEMA_FILE_NAME)
 
             // We can assert that the schema has been written successfully here as the schema
             // is shown in the type browser.
@@ -55,9 +61,9 @@ class TypeBrowserTest: IntegrationTest() {
         println("Starting collapseTypes.")
         studioTestWithRunner(composeRule) { address ->
             connectToTypeDB(composeRule, address)
-            cloneAndOpenProject(composeRule, source = TQL_DATA_PATH, destination = testID)
+            cloneAndOpenProject(composeRule, source = Utils.TQL_DATA_PATH, destination = testID)
             createDatabase(composeRule, dbName = testID)
-            writeSchemaInteractively(composeRule, dbName = testID, SCHEMA_FILE_NAME)
+            writeSchemaInteractively(composeRule, dbName = testID, Utils.SCHEMA_FILE_NAME)
 
             StudioState.client.session.tryOpen(database = testID, TypeDBSession.Type.DATA)
 
@@ -65,7 +71,7 @@ class TypeBrowserTest: IntegrationTest() {
             composeRule.onAllNodesWithText("Project").get(1).performClick()
             wait(composeRule, 500)
 
-            composeRule.onNodeWithText(DOUBLE_CHEVRON_UP_ICON_STRING).performClick()
+            composeRule.onNodeWithText(Utils.DOUBLE_CHEVRON_UP_ICON_STRING).performClick()
             wait(composeRule, 500)
 
             composeRule.onNodeWithText("commit-date").assertDoesNotExist()
@@ -80,18 +86,18 @@ class TypeBrowserTest: IntegrationTest() {
         println("Starting collapseThenExpandTypes.")
         studioTestWithRunner(composeRule) { address ->
             connectToTypeDB(composeRule, address)
-            cloneAndOpenProject(composeRule, source = TQL_DATA_PATH, destination = testID)
+            cloneAndOpenProject(composeRule, source = Utils.TQL_DATA_PATH, destination = testID)
             createDatabase(composeRule, dbName = testID)
-            writeSchemaInteractively(composeRule, dbName = testID, SCHEMA_FILE_NAME)
+            writeSchemaInteractively(composeRule, dbName = testID, Utils.SCHEMA_FILE_NAME)
 
             StudioState.client.session.tryOpen(database = testID, TypeDBSession.Type.DATA)
 
-            composeRule.onNodeWithText(DOUBLE_CHEVRON_UP_ICON_STRING).performClick()
+            composeRule.onNodeWithText(Utils.DOUBLE_CHEVRON_UP_ICON_STRING).performClick()
             wait(composeRule, 500)
 
             composeRule.onNodeWithText("commit-date").assertDoesNotExist()
 
-            composeRule.onNodeWithText(DOUBLE_CHEVRON_DOWN_ICON_STRING).performClick()
+            composeRule.onNodeWithText(Utils.DOUBLE_CHEVRON_DOWN_ICON_STRING).performClick()
             wait(composeRule, 500)
 
             composeRule.onNodeWithText("commit-date").assertExists()
@@ -107,9 +113,9 @@ class TypeBrowserTest: IntegrationTest() {
     fun exportSchema() {
         studioTestWithRunner(composeRule) { address ->
             connectToTypeDB(composeRule, address)
-            cloneAndOpenProject(composeRule, source = TQL_DATA_PATH, destination = testID)
+            cloneAndOpenProject(composeRule, source = Utils.TQL_DATA_PATH, destination = testID)
             createDatabase(composeRule, dbName = testID)
-            writeSchemaInteractively(composeRule, dbName = testID, SCHEMA_FILE_NAME)
+            writeSchemaInteractively(composeRule, dbName = testID, Utils.SCHEMA_FILE_NAME)
 
             StudioState.client.session.tryOpen(database = testID, TypeDBSession.Type.DATA)
 

--- a/test/integration/TypeBrowserTest.kt
+++ b/test/integration/TypeBrowserTest.kt
@@ -77,8 +77,6 @@ class TypeBrowserTest: IntegrationTest() {
             delayAndRecompose(composeRule)
 
             composeRule.onNodeWithText("commit-date").assertDoesNotExist()
-
-            StudioState.client.session.close()
         }
     }
 
@@ -101,8 +99,6 @@ class TypeBrowserTest: IntegrationTest() {
             delayAndRecompose(composeRule)
 
             composeRule.onNodeWithText("commit-date").assertExists()
-
-            StudioState.client.session.close()
         }
     }
 
@@ -130,8 +126,6 @@ class TypeBrowserTest: IntegrationTest() {
 
             composeRule.onNodeWithText("define").assertExists()
             composeRule.onNodeWithText("# This program is free software: you can redistribute it and/or modify").assertDoesNotExist()
-
-            StudioState.client.session.close()
         }
     }
 }

--- a/test/integration/Utils.kt
+++ b/test/integration/Utils.kt
@@ -96,7 +96,6 @@ object Utils {
     }
 
     fun cloneAndOpenProject(composeRule: ComposeContentTestRule, source: String, destination: String): Path {
-        println("Cloning and open the project.")
         val absolute = File(File(destination).absolutePath)
 
         absolute.deleteRecursively()
@@ -105,7 +104,6 @@ object Utils {
         StudioState.project.tryOpenProject(absolute.toPath())
 
         composeRule.waitForIdle()
-        println("Finished cloning and opening the project.")
         return absolute.toPath()
     }
 
@@ -116,7 +114,6 @@ object Utils {
     }
 
     suspend fun connectToTypeDB(composeRule: ComposeContentTestRule, address: String) {
-        println("Connecting to TypeDB.")
         // This opens a dialog box (which we can't see through) so we assert that buttons with that text can be
         // clicked.
         composeRule.onAllNodesWithText(Label.CONNECT_TO_TYPEDB).assertAll(hasClickAction())
@@ -127,11 +124,9 @@ object Utils {
         assertTrue(StudioState.client.isConnected)
 
         composeRule.onNodeWithText(address).assertExists()
-        println("Finished connecting to TypeDB.")
     }
 
     suspend fun createDatabase(composeRule: ComposeContentTestRule, dbName: String) {
-        println("Creating the database.")
         composeRule.onAllNodesWithText(Label.SELECT_DATABASE).assertAll(hasClickAction())
 
         StudioState.client.tryDeleteDatabase(dbName)
@@ -139,11 +134,9 @@ object Utils {
 
         StudioState.client.tryCreateDatabase(dbName) {}
         wait(composeRule, 750)
-        println("Finished creating the database.")
     }
 
     suspend fun writeSchemaInteractively(composeRule: ComposeContentTestRule, dbName: String, schemaFileName: String) {
-        println("Writing the schema interactively.")
         composeRule.onNodeWithText(PLUS_ICON_STRING).performClick()
         wait(composeRule, 750)
 
@@ -165,11 +158,9 @@ object Utils {
         wait(composeRule, 1_500)
 
         StudioState.client.session.close()
-        println("Finished writing the schema interactively.")
     }
 
     suspend fun writeDataInteractively(composeRule: ComposeContentTestRule, dbName: String, dataFileName: String) {
-        println("Writing the data interactively.")
         StudioState.client.session.tryOpen(dbName, TypeDBSession.Type.DATA)
 
         wait(composeRule, 750)
@@ -186,11 +177,9 @@ object Utils {
         wait(composeRule, 1_500)
 
         StudioState.client.session.close()
-        println("Finished writing the schema interactively.")
     }
 
     suspend fun verifyDataWrite(composeRule: ComposeContentTestRule, address: String, dbName: String, queryFileName: String) {
-        println("Verifying the data was written.")
         val queryString = fileNameToString(queryFileName)
 
         composeRule.onNodeWithText("infer").performClick()
@@ -214,7 +203,6 @@ object Utils {
                 }
             }
         }
-        println("Finished verifying the data was written.")
     }
 }
 

--- a/test/integration/Utils.kt
+++ b/test/integration/Utils.kt
@@ -123,8 +123,8 @@ object Utils {
         composeRule.onAllNodesWithText(Label.CONNECT_TO_TYPEDB).assertAll(hasClickAction())
 
         StudioState.client.tryConnectToTypeDB(address) {}
-        // Resolving localhost can take up to 5 seconds on macOS
-        wait(composeRule, 5_000)
+
+        wait(composeRule, 2_500)
         assertTrue(StudioState.client.isConnected)
 
         composeRule.onNodeWithText(address).assertExists()
@@ -136,23 +136,23 @@ object Utils {
         composeRule.onAllNodesWithText(Label.SELECT_DATABASE).assertAll(hasClickAction())
 
         StudioState.client.tryDeleteDatabase(dbName)
-        wait(composeRule, 500)
+        wait(composeRule, 750)
 
         StudioState.client.tryCreateDatabase(dbName) {}
-        wait(composeRule, 500)
+        wait(composeRule, 750)
         println("Finished creating the database.")
     }
 
     suspend fun writeSchemaInteractively(composeRule: ComposeContentTestRule, dbName: String, schemaFileName: String) {
         println("Writing the schema interactively.")
         composeRule.onNodeWithText(PLUS_ICON_STRING).performClick()
-        wait(composeRule, 500)
+        wait(composeRule, 750)
 
         StudioState.client.session.tryOpen(dbName, TypeDBSession.Type.SCHEMA)
-        wait(composeRule, 500)
+        wait(composeRule, 750)
 
         StudioState.client.tryUpdateTransactionType(TypeDBTransaction.Type.WRITE)
-        wait(composeRule, 500)
+        wait(composeRule, 750)
 
         composeRule.onNodeWithText("schema").performClick()
         composeRule.onNodeWithText("write").performClick()
@@ -160,10 +160,10 @@ object Utils {
         StudioState.project.current!!.directory.entries.find { it.name == schemaFileName }!!.asFile().tryOpen()
 
         composeRule.onNodeWithText(PLAY_ICON_STRING).performClick()
-        wait(composeRule, 2_500)
+        wait(composeRule, 750)
 
         composeRule.onNodeWithText(CHECK_ICON_STRING).performClick()
-        wait(composeRule, 500)
+        wait(composeRule, 750)
 
         StudioState.client.session.close()
         println("Finished writing the schema interactively.")
@@ -173,7 +173,7 @@ object Utils {
         println("Writing the data interactively.")
         StudioState.client.session.tryOpen(dbName, TypeDBSession.Type.DATA)
 
-        wait(composeRule, 500)
+        wait(composeRule, 750)
 
         composeRule.onNodeWithText("data").performClick()
         composeRule.onNodeWithText("write").performClick()
@@ -181,10 +181,10 @@ object Utils {
         StudioState.project.current!!.directory.entries.find { it.name == dataFileName }!!.asFile().tryOpen()
 
         composeRule.onNodeWithText(PLAY_ICON_STRING).performClick()
-        wait(composeRule, 2_500)
+        wait(composeRule, 750)
 
         composeRule.onNodeWithText(CHECK_ICON_STRING).performClick()
-        wait(composeRule, 500)
+        wait(composeRule, 750)
 
         StudioState.client.session.close()
         println("Finished writing the schema interactively.")

--- a/test/integration/Utils.kt
+++ b/test/integration/Utils.kt
@@ -37,8 +37,6 @@ import com.vaticle.typedb.studio.framework.common.WindowContext
 import com.vaticle.typedb.studio.framework.material.Icon
 import com.vaticle.typedb.studio.state.StudioState
 import com.vaticle.typedb.studio.state.common.util.Label
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.runBlocking
 import java.io.File
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
@@ -47,6 +45,8 @@ import java.nio.file.Paths
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlin.test.fail
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
 
 object Utils {
     val SAVE_ICON_STRING = Icon.Code.FLOPPY_DISK.unicode
@@ -81,7 +81,7 @@ object Utils {
             }
             funcBody()
         }
-}
+    }
 
     fun studioTestWithRunner(compose: ComposeContentTestRule, funcBody: suspend (String) -> Unit) {
         val typeDB = TypeDBCoreRunner()
@@ -178,8 +178,6 @@ object Utils {
         delayAndRecompose(composeRule, Delays.NETWORK_IO)
 
         waitForConditionAndRecompose({ StudioState.notification.queue.last().code == "CNX10" }, {}, FAIL_SCHEMA_WRITE, composeRule)
-
-        StudioState.client.session.close()
     }
 
     suspend fun writeDataInteractively(composeRule: ComposeContentTestRule, dbName: String, dataFileName: String) {
@@ -201,8 +199,6 @@ object Utils {
         delayAndRecompose(composeRule, Delays.NETWORK_IO)
 
         waitForConditionAndRecompose({ StudioState.notification.queue.last().code == "CNX10" }, {}, FAIL_DATA_WRITE, composeRule)
-
-        StudioState.client.session.close()
     }
 
     suspend fun verifyDataWrite(composeRule: ComposeContentTestRule, address: String, dbName: String, queryFileName: String) {

--- a/test/integration/Utils.kt
+++ b/test/integration/Utils.kt
@@ -74,13 +74,13 @@ object Utils {
         runBlocking { compose.rule() }
     }
 
-fun studioTest(compose: ComposeContentTestRule, funcBody: suspend () -> Unit) {
-    runComposeRule(compose) {
-        setContent {
-            Studio.MainWindowContent(WindowContext.Test(1000, 1000, 0, 0))
+    fun studioTest(compose: ComposeContentTestRule, funcBody: suspend () -> Unit) {
+        runComposeRule(compose) {
+            setContent {
+                Studio.MainWindowContent(WindowContext.Test(1000, 1000, 0, 0))
+            }
+            funcBody()
         }
-        funcBody()
-    }
 }
 
     fun studioTestWithRunner(compose: ComposeContentTestRule, funcBody: suspend (String) -> Unit) {

--- a/test/integration/Utils.kt
+++ b/test/integration/Utils.kt
@@ -63,8 +63,6 @@ const val QUERY_FILE_NAME = "query_string.tql"
 const val DATA_FILE_NAME = "data_string.tql"
 const val SCHEMA_FILE_NAME = "schema_string.tql"
 
-const val DB_ADDRESS = "localhost:1729"
-
 fun runComposeRule(compose: ComposeContentTestRule, rule: suspend ComposeContentTestRule.() -> Unit) {
     runBlocking { compose.rule() }
 }
@@ -168,7 +166,7 @@ suspend fun writeDataInteractively(composeRule: ComposeContentTestRule, dbName: 
     StudioState.client.session.close()
 }
 
-suspend fun verifyDataWrite(composeRule: ComposeContentTestRule, dbName: String, queryFileName: String) {
+suspend fun verifyDataWrite(composeRule: ComposeContentTestRule, address: String, dbName: String, queryFileName: String) {
     val queryString = fileNameToString(queryFileName)
 
     composeRule.onNodeWithText("infer").performClick()
@@ -176,7 +174,7 @@ suspend fun verifyDataWrite(composeRule: ComposeContentTestRule, dbName: String,
     composeRule.onNodeWithText("read").performClick()
     wait(composeRule, 1_000)
 
-    TypeDB.coreClient(DB_ADDRESS).use { client ->
+    TypeDB.coreClient(address).use { client ->
         client.session(dbName, TypeDBSession.Type.DATA, TypeDBOptions.core().infer(true)).use { session ->
             session.transaction(TypeDBTransaction.Type.READ).use { transaction ->
                 val results = ArrayList<String>()

--- a/test/integration/Utils.kt
+++ b/test/integration/Utils.kt
@@ -103,7 +103,6 @@ object Utils {
         File(source).copyRecursively(overwrite = true, target = absolute)
 
         StudioState.project.tryOpenProject(absolute.toPath())
-        StudioState.appData.project.path = absolute.toPath()
 
         composeRule.waitForIdle()
         println("Finished cloning and opening the project.")
@@ -163,7 +162,7 @@ object Utils {
         wait(composeRule, 750)
 
         composeRule.onNodeWithText(CHECK_ICON_STRING).performClick()
-        wait(composeRule, 750)
+        wait(composeRule, 1_500)
 
         StudioState.client.session.close()
         println("Finished writing the schema interactively.")
@@ -184,7 +183,7 @@ object Utils {
         wait(composeRule, 750)
 
         composeRule.onNodeWithText(CHECK_ICON_STRING).performClick()
-        wait(composeRule, 750)
+        wait(composeRule, 1_500)
 
         StudioState.client.session.close()
         println("Finished writing the schema interactively.")

--- a/test/integration/Utils.kt
+++ b/test/integration/Utils.kt
@@ -47,174 +47,175 @@ import java.nio.file.Paths
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
+object Utils {
+    val SAVE_ICON_STRING = Icon.Code.FLOPPY_DISK.unicode
+    val PLUS_ICON_STRING = Icon.Code.PLUS.unicode
+    val PLAY_ICON_STRING = Icon.Code.PLAY.unicode
+    val CHECK_ICON_STRING = Icon.Code.CHECK.unicode
+    val ROLLBACK_ICON_STRING = Icon.Code.ROTATE_LEFT.unicode
+    val CHEVRON_UP_ICON_STRING = Icon.Code.CHEVRON_UP.unicode
+    val DOUBLE_CHEVRON_DOWN_ICON_STRING = Icon.Code.CHEVRONS_DOWN.unicode
+    val DOUBLE_CHEVRON_UP_ICON_STRING = Icon.Code.CHEVRONS_UP.unicode
 
-val SAVE_ICON_STRING = Icon.Code.FLOPPY_DISK.unicode
-val PLUS_ICON_STRING = Icon.Code.PLUS.unicode
-val PLAY_ICON_STRING = Icon.Code.PLAY.unicode
-val CHECK_ICON_STRING = Icon.Code.CHECK.unicode
-val ROLLBACK_ICON_STRING = Icon.Code.ROTATE_LEFT.unicode
-val CHEVRON_UP_ICON_STRING = Icon.Code.CHEVRON_UP.unicode
-val DOUBLE_CHEVRON_DOWN_ICON_STRING = Icon.Code.CHEVRONS_DOWN.unicode
-val DOUBLE_CHEVRON_UP_ICON_STRING = Icon.Code.CHEVRONS_UP.unicode
+    val SAMPLE_DATA_PATH = File("test/data/sample_file_structure").absolutePath
+    val TQL_DATA_PATH = File("test/data").absolutePath
 
-val SAMPLE_DATA_PATH = File("test/data/sample_file_structure").absolutePath
-val TQL_DATA_PATH = File("test/data").absolutePath
+    const val QUERY_FILE_NAME = "query_string.tql"
+    const val DATA_FILE_NAME = "data_string.tql"
+    const val SCHEMA_FILE_NAME = "schema_string.tql"
 
-const val QUERY_FILE_NAME = "query_string.tql"
-const val DATA_FILE_NAME = "data_string.tql"
-const val SCHEMA_FILE_NAME = "schema_string.tql"
-
-fun runComposeRule(compose: ComposeContentTestRule, rule: suspend ComposeContentTestRule.() -> Unit) {
-    runBlocking { compose.rule() }
-}
-
-fun studioTest(compose: ComposeContentTestRule, funcBody: suspend () -> Unit) {
-    runComposeRule(compose) {
-        setContent {
-            Studio.MainWindowContent(WindowContext(1000, 1000, 0, 0))
-        }
-        funcBody()
+    fun runComposeRule(compose: ComposeContentTestRule, rule: suspend ComposeContentTestRule.() -> Unit) {
+        runBlocking { compose.rule() }
     }
-}
 
-fun studioTestWithRunner(compose: ComposeContentTestRule, funcBody: suspend (String) -> Unit) {
-    val typeDB = TypeDBCoreRunner()
-    typeDB.start()
-    val address = typeDB.address()
-    runComposeRule(compose) {
-        setContent {
-            Studio.MainWindowContent(WindowContext(1000, 1000, 0, 0))
+    fun studioTest(compose: ComposeContentTestRule, funcBody: suspend () -> Unit) {
+        runComposeRule(compose) {
+            setContent {
+                Studio.MainWindowContent(WindowContext(1000, 1000, 0, 0))
+            }
+            funcBody()
         }
-        funcBody(address)
     }
-    typeDB.stop()
-}
 
-fun fileNameToString(fileName: String): String {
-    return Files.readAllLines(Paths.get(fileName), StandardCharsets.UTF_8).filter { line -> !line.startsWith('#') }
-        .joinToString("")
-}
+    fun studioTestWithRunner(compose: ComposeContentTestRule, funcBody: suspend (String) -> Unit) {
+        val typeDB = TypeDBCoreRunner()
+        typeDB.start()
+        val address = typeDB.address()
+        runComposeRule(compose) {
+            setContent {
+                Studio.MainWindowContent(WindowContext(1000, 1000, 0, 0))
+            }
+            funcBody(address)
+        }
+        typeDB.stop()
+    }
 
-fun cloneAndOpenProject(composeRule: ComposeContentTestRule, source: String, destination: String): Path {
-    println("Cloning and open the project.")
-    val absolute = File(File(destination).absolutePath)
+    fun fileNameToString(fileName: String): String {
+        return Files.readAllLines(Paths.get(fileName), StandardCharsets.UTF_8).filter { line -> !line.startsWith('#') }
+            .joinToString("")
+    }
 
-    absolute.deleteRecursively()
-    File(source).copyRecursively(overwrite = true, target = absolute)
+    fun cloneAndOpenProject(composeRule: ComposeContentTestRule, source: String, destination: String): Path {
+        println("Cloning and open the project.")
+        val absolute = File(File(destination).absolutePath)
 
-    StudioState.project.tryOpenProject(absolute.toPath())
-    StudioState.appData.project.path = absolute.toPath()
+        absolute.deleteRecursively()
+        File(source).copyRecursively(overwrite = true, target = absolute)
 
-    composeRule.waitForIdle()
-    println("Finished cloning and opening the project.")
-    return absolute.toPath()
-}
+        StudioState.project.tryOpenProject(absolute.toPath())
+        StudioState.appData.project.path = absolute.toPath()
 
-/// Wait `timeMillis` milliseconds, then wait for all recompositions to finish.
-suspend fun wait(composeRule: ComposeContentTestRule, timeMillis: Int) {
-    delay(timeMillis.toLong())
-    composeRule.waitForIdle()
-}
+        composeRule.waitForIdle()
+        println("Finished cloning and opening the project.")
+        return absolute.toPath()
+    }
 
-suspend fun connectToTypeDB(composeRule: ComposeContentTestRule, address: String) {
-    println("Connecting to TypeDB.")
-    // This opens a dialog box (which we can't see through) so we assert that buttons with that text can be
-    // clicked.
-    composeRule.onAllNodesWithText(Label.CONNECT_TO_TYPEDB).assertAll(hasClickAction())
+    /// Wait `timeMillis` milliseconds, then wait for all recompositions to finish.
+    suspend fun wait(composeRule: ComposeContentTestRule, timeMillis: Int) {
+        delay(timeMillis.toLong())
+        composeRule.waitForIdle()
+    }
 
-    StudioState.client.tryConnectToTypeDB(address) {}
-    // Resolving localhost can take up to 5 seconds on macOS
-    wait(composeRule, 5_000)
-    assertTrue(StudioState.client.isConnected)
+    suspend fun connectToTypeDB(composeRule: ComposeContentTestRule, address: String) {
+        println("Connecting to TypeDB.")
+        // This opens a dialog box (which we can't see through) so we assert that buttons with that text can be
+        // clicked.
+        composeRule.onAllNodesWithText(Label.CONNECT_TO_TYPEDB).assertAll(hasClickAction())
 
-    composeRule.onNodeWithText(address).assertExists()
-    println("Finished connecting to TypeDB.")
-}
+        StudioState.client.tryConnectToTypeDB(address) {}
+        // Resolving localhost can take up to 5 seconds on macOS
+        wait(composeRule, 5_000)
+        assertTrue(StudioState.client.isConnected)
 
-suspend fun createDatabase(composeRule: ComposeContentTestRule, dbName: String) {
-    println("Creating the database.")
-    composeRule.onAllNodesWithText(Label.SELECT_DATABASE).assertAll(hasClickAction())
+        composeRule.onNodeWithText(address).assertExists()
+        println("Finished connecting to TypeDB.")
+    }
 
-    StudioState.client.tryDeleteDatabase(dbName)
-    wait(composeRule, 500)
+    suspend fun createDatabase(composeRule: ComposeContentTestRule, dbName: String) {
+        println("Creating the database.")
+        composeRule.onAllNodesWithText(Label.SELECT_DATABASE).assertAll(hasClickAction())
 
-    StudioState.client.tryCreateDatabase(dbName) {}
-    wait(composeRule, 500)
-    println("Finished creating the database.")
-}
+        StudioState.client.tryDeleteDatabase(dbName)
+        wait(composeRule, 500)
 
-suspend fun writeSchemaInteractively(composeRule: ComposeContentTestRule, dbName: String, schemaFileName: String) {
-    println("Writing the schema interactively.")
-    composeRule.onNodeWithText(PLUS_ICON_STRING).performClick()
-    wait(composeRule, 500)
+        StudioState.client.tryCreateDatabase(dbName) {}
+        wait(composeRule, 500)
+        println("Finished creating the database.")
+    }
 
-    StudioState.client.session.tryOpen(dbName, TypeDBSession.Type.SCHEMA)
-    wait(composeRule, 500)
+    suspend fun writeSchemaInteractively(composeRule: ComposeContentTestRule, dbName: String, schemaFileName: String) {
+        println("Writing the schema interactively.")
+        composeRule.onNodeWithText(PLUS_ICON_STRING).performClick()
+        wait(composeRule, 500)
 
-    StudioState.client.tryUpdateTransactionType(TypeDBTransaction.Type.WRITE)
-    wait(composeRule, 500)
+        StudioState.client.session.tryOpen(dbName, TypeDBSession.Type.SCHEMA)
+        wait(composeRule, 500)
 
-    composeRule.onNodeWithText("schema").performClick()
-    composeRule.onNodeWithText("write").performClick()
+        StudioState.client.tryUpdateTransactionType(TypeDBTransaction.Type.WRITE)
+        wait(composeRule, 500)
 
-    StudioState.project.current!!.directory.entries.find { it.name == schemaFileName }!!.asFile().tryOpen()
+        composeRule.onNodeWithText("schema").performClick()
+        composeRule.onNodeWithText("write").performClick()
 
-    composeRule.onNodeWithText(PLAY_ICON_STRING).performClick()
-    wait(composeRule, 2_500)
+        StudioState.project.current!!.directory.entries.find { it.name == schemaFileName }!!.asFile().tryOpen()
 
-    composeRule.onNodeWithText(CHECK_ICON_STRING).performClick()
-    wait(composeRule, 500)
+        composeRule.onNodeWithText(PLAY_ICON_STRING).performClick()
+        wait(composeRule, 2_500)
 
-    StudioState.client.session.close()
-    println("Finished writing the schema interactively.")
-}
+        composeRule.onNodeWithText(CHECK_ICON_STRING).performClick()
+        wait(composeRule, 500)
 
-suspend fun writeDataInteractively(composeRule: ComposeContentTestRule, dbName: String, dataFileName: String) {
-    println("Writing the data interactively.")
-    StudioState.client.session.tryOpen(dbName, TypeDBSession.Type.DATA)
+        StudioState.client.session.close()
+        println("Finished writing the schema interactively.")
+    }
 
-    wait(composeRule, 500)
+    suspend fun writeDataInteractively(composeRule: ComposeContentTestRule, dbName: String, dataFileName: String) {
+        println("Writing the data interactively.")
+        StudioState.client.session.tryOpen(dbName, TypeDBSession.Type.DATA)
 
-    composeRule.onNodeWithText("data").performClick()
-    composeRule.onNodeWithText("write").performClick()
+        wait(composeRule, 500)
 
-    StudioState.project.current!!.directory.entries.find { it.name == dataFileName }!!.asFile().tryOpen()
+        composeRule.onNodeWithText("data").performClick()
+        composeRule.onNodeWithText("write").performClick()
 
-    composeRule.onNodeWithText(PLAY_ICON_STRING).performClick()
-    wait(composeRule, 2_500)
+        StudioState.project.current!!.directory.entries.find { it.name == dataFileName }!!.asFile().tryOpen()
 
-    composeRule.onNodeWithText(CHECK_ICON_STRING).performClick()
-    wait(composeRule, 500)
+        composeRule.onNodeWithText(PLAY_ICON_STRING).performClick()
+        wait(composeRule, 2_500)
 
-    StudioState.client.session.close()
-    println("Finished writing the schema interactively.")
-}
+        composeRule.onNodeWithText(CHECK_ICON_STRING).performClick()
+        wait(composeRule, 500)
 
-suspend fun verifyDataWrite(composeRule: ComposeContentTestRule, address: String, dbName: String, queryFileName: String) {
-    println("Verifying the data was written.")
-    val queryString = fileNameToString(queryFileName)
+        StudioState.client.session.close()
+        println("Finished writing the schema interactively.")
+    }
 
-    composeRule.onNodeWithText("infer").performClick()
-    composeRule.waitForIdle()
-    composeRule.onNodeWithText("read").performClick()
-    wait(composeRule, 1_000)
+    suspend fun verifyDataWrite(composeRule: ComposeContentTestRule, address: String, dbName: String, queryFileName: String) {
+        println("Verifying the data was written.")
+        val queryString = fileNameToString(queryFileName)
 
-    TypeDB.coreClient(address).use { client ->
-        client.session(dbName, TypeDBSession.Type.DATA, TypeDBOptions.core().infer(true)).use { session ->
-            session.transaction(TypeDBTransaction.Type.READ).use { transaction ->
-                val results = ArrayList<String>()
-                val query = TypeQL.parseQuery<TypeQLMatch>(queryString)
-                transaction.query().match(query).forEach { result ->
-                    results.add(
-                        result.get("user-name").asAttribute().value.toString()
-                    )
+        composeRule.onNodeWithText("infer").performClick()
+        composeRule.waitForIdle()
+        composeRule.onNodeWithText("read").performClick()
+        wait(composeRule, 1_000)
+
+        TypeDB.coreClient(address).use { client ->
+            client.session(dbName, TypeDBSession.Type.DATA, TypeDBOptions.core().infer(true)).use { session ->
+                session.transaction(TypeDBTransaction.Type.READ).use { transaction ->
+                    val results = ArrayList<String>()
+                    val query = TypeQL.parseQuery<TypeQLMatch>(queryString)
+                    transaction.query().match(query).forEach { result ->
+                        results.add(
+                            result.get("user-name").asAttribute().value.toString()
+                        )
+                    }
+                    assertEquals(2, results.size)
+                    assertTrue(results.contains("jmsfltchr"))
+                    assertTrue(results.contains("krishnangovindraj"))
                 }
-                assertEquals(2, results.size)
-                assertTrue(results.contains("jmsfltchr"))
-                assertTrue(results.contains("krishnangovindraj"))
             }
         }
+        println("Finished verifying the data was written.")
     }
-    println("Finished verifying the data was written.")
 }
 

--- a/test/integration/Utils.kt
+++ b/test/integration/Utils.kt
@@ -29,6 +29,7 @@ import com.vaticle.typedb.client.TypeDB
 import com.vaticle.typedb.client.api.TypeDBOptions
 import com.vaticle.typedb.client.api.TypeDBSession
 import com.vaticle.typedb.client.api.TypeDBTransaction
+import com.vaticle.typedb.common.test.core.TypeDBCoreRunner
 import com.vaticle.typeql.lang.TypeQL
 import com.vaticle.typeql.lang.query.TypeQLMatch
 import com.vaticle.typedb.studio.Studio
@@ -74,6 +75,19 @@ fun studioTest(compose: ComposeContentTestRule, funcBody: suspend () -> Unit) {
         }
         funcBody()
     }
+}
+
+fun studioTestWithRunner(compose: ComposeContentTestRule, funcBody: suspend (String) -> Unit) {
+    val typeDB = TypeDBCoreRunner()
+    typeDB.start()
+    val address = typeDB.address()
+    runComposeRule(compose) {
+        setContent {
+            Studio.MainWindowContent(WindowContext(1000, 1000, 0, 0))
+        }
+        funcBody(address)
+    }
+    typeDB.stop()
 }
 
 fun fileNameToString(fileName: String): String {

--- a/test/integration/Utils.kt
+++ b/test/integration/Utils.kt
@@ -134,7 +134,7 @@ object Utils {
         StudioState.client.tryConnectToTypeDB(address) {}
         delayAndRecompose(composeRule, Delays.CONNECT_SERVER)
 
-        waitForConditionAndRecompose({StudioState.client.isConnected}, {}, FAIL_CONNECT_TYPEDB, composeRule)
+        waitForConditionAndRecompose({ StudioState.client.isConnected }, {}, FAIL_CONNECT_TYPEDB, composeRule)
 
         composeRule.onNodeWithText(address).assertExists()
     }
@@ -161,7 +161,7 @@ object Utils {
         delayAndRecompose(composeRule)
 
         StudioState.client.session.tryOpen(dbName, TypeDBSession.Type.SCHEMA)
-        delayAndRecompose(composeRule)
+        delayAndRecompose(composeRule, Delays.NETWORK_IO)
 
         StudioState.client.tryUpdateTransactionType(TypeDBTransaction.Type.WRITE)
         delayAndRecompose(composeRule, Delays.NETWORK_IO)
@@ -177,7 +177,7 @@ object Utils {
         composeRule.onNodeWithText(CHECK_ICON_STRING).performClick()
         delayAndRecompose(composeRule, Delays.NETWORK_IO)
 
-        waitForConditionAndRecompose({StudioState.notification.queue.last().code == "CNX10"}, {}, FAIL_SCHEMA_WRITE, composeRule)
+        waitForConditionAndRecompose({ StudioState.notification.queue.last().code == "CNX10" }, {}, FAIL_SCHEMA_WRITE, composeRule)
 
         StudioState.client.session.close()
     }
@@ -200,7 +200,7 @@ object Utils {
         composeRule.onNodeWithText(CHECK_ICON_STRING).performClick()
         delayAndRecompose(composeRule, Delays.NETWORK_IO)
 
-        waitForConditionAndRecompose({StudioState.notification.queue.last().code == "CNX10"}, {}, FAIL_DATA_WRITE, composeRule)
+        waitForConditionAndRecompose({ StudioState.notification.queue.last().code == "CNX10" }, {}, FAIL_DATA_WRITE, composeRule)
 
         StudioState.client.session.close()
     }

--- a/test/integration/Utils.kt
+++ b/test/integration/Utils.kt
@@ -96,6 +96,7 @@ fun fileNameToString(fileName: String): String {
 }
 
 fun cloneAndOpenProject(composeRule: ComposeContentTestRule, source: String, destination: String): Path {
+    println("Cloning and open the project.")
     val absolute = File(File(destination).absolutePath)
 
     absolute.deleteRecursively()
@@ -105,6 +106,7 @@ fun cloneAndOpenProject(composeRule: ComposeContentTestRule, source: String, des
     StudioState.appData.project.path = absolute.toPath()
 
     composeRule.waitForIdle()
+    println("Finished cloning and opening the project.")
     return absolute.toPath()
 }
 
@@ -115,6 +117,7 @@ suspend fun wait(composeRule: ComposeContentTestRule, timeMillis: Int) {
 }
 
 suspend fun connectToTypeDB(composeRule: ComposeContentTestRule, address: String) {
+    println("Connecting to TypeDB.")
     // This opens a dialog box (which we can't see through) so we assert that buttons with that text can be
     // clicked.
     composeRule.onAllNodesWithText(Label.CONNECT_TO_TYPEDB).assertAll(hasClickAction())
@@ -125,9 +128,11 @@ suspend fun connectToTypeDB(composeRule: ComposeContentTestRule, address: String
     assertTrue(StudioState.client.isConnected)
 
     composeRule.onNodeWithText(address).assertExists()
+    println("Finished connecting to TypeDB.")
 }
 
 suspend fun createDatabase(composeRule: ComposeContentTestRule, dbName: String) {
+    println("Creating the database.")
     composeRule.onAllNodesWithText(Label.SELECT_DATABASE).assertAll(hasClickAction())
 
     StudioState.client.tryDeleteDatabase(dbName)
@@ -135,9 +140,11 @@ suspend fun createDatabase(composeRule: ComposeContentTestRule, dbName: String) 
 
     StudioState.client.tryCreateDatabase(dbName) {}
     wait(composeRule, 500)
+    println("Finished creating the database.")
 }
 
 suspend fun writeSchemaInteractively(composeRule: ComposeContentTestRule, dbName: String, schemaFileName: String) {
+    println("Writing the schema interactively.")
     composeRule.onNodeWithText(PLUS_ICON_STRING).performClick()
     wait(composeRule, 500)
 
@@ -159,9 +166,11 @@ suspend fun writeSchemaInteractively(composeRule: ComposeContentTestRule, dbName
     wait(composeRule, 500)
 
     StudioState.client.session.close()
+    println("Finished writing the schema interactively.")
 }
 
 suspend fun writeDataInteractively(composeRule: ComposeContentTestRule, dbName: String, dataFileName: String) {
+    println("Writing the data interactively.")
     StudioState.client.session.tryOpen(dbName, TypeDBSession.Type.DATA)
 
     wait(composeRule, 500)
@@ -178,9 +187,11 @@ suspend fun writeDataInteractively(composeRule: ComposeContentTestRule, dbName: 
     wait(composeRule, 500)
 
     StudioState.client.session.close()
+    println("Finished writing the schema interactively.")
 }
 
 suspend fun verifyDataWrite(composeRule: ComposeContentTestRule, address: String, dbName: String, queryFileName: String) {
+    println("Verifying the data was written.")
     val queryString = fileNameToString(queryFileName)
 
     composeRule.onNodeWithText("infer").performClick()
@@ -204,5 +215,6 @@ suspend fun verifyDataWrite(composeRule: ComposeContentTestRule, address: String
             }
         }
     }
+    println("Finished verifying the data was written.")
 }
 


### PR DESCRIPTION
## What is the goal of this PR?

The Studio tests that required an instance of TypeDB have been migrated to using `typedb_kt_test`, which use `typedb-runner` to provide TypeDB to the tests rather than `typedb-extractor`. This migration has provided stability, increased hermeticity and the opportunity to test Studio's interactions with cluster in the future.

## What are the changes implemented in this PR?
Studio tests that connect to TypeDB now use `typedb_kt_test`, a newly provided test rule from typedb-common that allow us to make use of TypeDB runners.

Utils is now an Object rather than a standalone set of functions and variables. It also provides a new test function `studioTestWithRunner`. Some Studio tests don't require the use of TypeDB and waiting for TypeDB to run is wasteful in those instances.

Studio tests are now stable in CI through an increase in delays to allow for the less compute-heavy machines in CI time to process UI recomposition and perform local network actions.