### PR TITLE
Fix WindowContext not reflecting changes to window size

### DIFF
--- a/Studio.kt
+++ b/Studio.kt
@@ -144,9 +144,9 @@ object Studio {
             onCloseRequest = { if (error != null) exitApplicationFn() else confirmClose() },
         ) {
             CompositionLocalProvider(LocalWindow provides window) {
-                val windowContext = WindowContext(window)
+                val windowContext = WindowContext.Compose(window)
+                MainWindowContent(windowContext)
                 CompositionLocalProvider(LocalWindowContext provides windowContext) {
-                    MainWindowContent(windowContext)
                     Notifications.MayShowPopup()
                     ConfirmationDialog.MayShowDialog()
                     ServerDialog.MayShowDialogs()
@@ -163,6 +163,7 @@ object Studio {
         val density = LocalDensity.current.density
         Column(Modifier.fillMaxSize().background(Theme.studio.backgroundMedium).onGloballyPositioned {
             titleBarHeight = window.height.dp - toDP(it.size.height, density)
+            println(titleBarHeight)
         }) {
             CompositionLocalProvider(LocalWindowContext provides window) {
                 CompositionLocalProvider(LocalTitleBarHeight provides titleBarHeight) {

--- a/Studio.kt
+++ b/Studio.kt
@@ -163,7 +163,6 @@ object Studio {
         val density = LocalDensity.current.density
         Column(Modifier.fillMaxSize().background(Theme.studio.backgroundMedium).onGloballyPositioned {
             titleBarHeight = window.height.dp - toDP(it.size.height, density)
-            println(titleBarHeight)
         }) {
             CompositionLocalProvider(LocalWindowContext provides window) {
                 CompositionLocalProvider(LocalTitleBarHeight provides titleBarHeight) {

--- a/framework/common/WindowContext.kt
+++ b/framework/common/WindowContext.kt
@@ -35,14 +35,14 @@ sealed interface WindowContext {
 
         override var width: Int
             get() = window.size.height
-            set(value) {value}
+            set(value) { value }
 
         override var x: Int
             get() = window.x
-            set(value) {value}
+            set(value) { value }
 
         override var y: Int
             get() = window.y
-            set(value) {value}
+            set(value) { value }
     }
 }

--- a/framework/common/WindowContext.kt
+++ b/framework/common/WindowContext.kt
@@ -21,11 +21,11 @@ package com.vaticle.typedb.studio.framework.common
 import androidx.compose.ui.awt.ComposeWindow
 
 sealed interface WindowContext {
-
     var height: Int
     var width: Int
     var x: Int
     var y: Int
+
     class Test(override var height: Int, override var width: Int, override var x: Int, override var y: Int): WindowContext
 
     class Compose(val window: ComposeWindow): WindowContext {

--- a/framework/common/WindowContext.kt
+++ b/framework/common/WindowContext.kt
@@ -31,7 +31,7 @@ sealed interface WindowContext {
     class Compose(val window: ComposeWindow): WindowContext {
         override var height: Int
             get() = window.size.height
-            set(value) {value}
+            set(value) { value }
 
         override var width: Int
             get() = window.size.height

--- a/framework/common/WindowContext.kt
+++ b/framework/common/WindowContext.kt
@@ -20,6 +20,29 @@ package com.vaticle.typedb.studio.framework.common
 
 import androidx.compose.ui.awt.ComposeWindow
 
-class WindowContext(val height: Int, val width: Int, val x: Int, val y: Int) {
-    constructor(window: ComposeWindow): this(window.height, window.width, window.x, window.y)
+sealed interface WindowContext {
+
+    var height: Int
+    var width: Int
+    var x: Int
+    var y: Int
+    class Test(override var height: Int, override var width: Int, override var x: Int, override var y: Int): WindowContext
+
+    class Compose(val window: ComposeWindow): WindowContext {
+        override var height: Int
+            get() = window.size.height
+            set(value) {value}
+
+        override var width: Int
+            get() = window.size.height
+            set(value) {value}
+
+        override var x: Int
+            get() = window.x
+            set(value) {value}
+
+        override var y: Int
+            get() = window.y
+            set(value) {value}
+    }
 }

--- a/test/integration/Utils.kt
+++ b/test/integration/Utils.kt
@@ -72,7 +72,7 @@ fun runComposeRule(compose: ComposeContentTestRule, rule: suspend ComposeContent
 fun studioTest(compose: ComposeContentTestRule, funcBody: suspend () -> Unit) {
     runComposeRule(compose) {
         setContent {
-            Studio.MainWindowContent(WindowContext(1000, 1000, 0, 0))
+            Studio.MainWindowContent(WindowContext.Test(1000, 1000, 0, 0))
         }
         funcBody()
     }


### PR DESCRIPTION
## What is the goal of this PR?

We fixed a bug in `WindowContext` where resizing the underlying window was not reflected when getting its values (i.e. height, width, x and y). This fixes a bug where certain actions such as mouse hovering didn't render tooltips because of windowContext reporting the incorrect height and width.

## What are the changes implemented in this PR?

We've expanded WindowContext so that it includes 2 inner classes:
- Test, a 'mock' testing window context.
- Compose, a window context that links to the window itself when Studio is launched with a window.

