### PR TITLE
Provide window context for error windows

### DIFF
--- a/Studio.kt
+++ b/Studio.kt
@@ -243,28 +243,31 @@ object Studio {
                 "${Label.TITLE}: ${exception.message}\n${Label.TRACE}: ${exception.stackTraceToString()}"
 
             CompositionLocalProvider(LocalWindow provides window) {
-                Column(
-                    modifier = Modifier.fillMaxSize().background(Theme.studio.backgroundMedium)
-                        .padding(DIALOG_PADDING),
-                    verticalArrangement = Arrangement.spacedBy(DIALOG_PADDING)
-                ) {
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Text(value = "${Label.TITLE}:", modifier = labelModifier, textStyle = labelStyle)
-                        exception.message?.let { SelectableText(value = it, color = contentColor) }
-                    }
-                    Row(Modifier.weight(1f)) {
-                        Text(value = "${Label.TRACE}:", modifier = labelModifier, textStyle = labelStyle)
-                        SelectableText(
-                            value = exception.stackTraceToString(), color = contentColor, modifier = contentModifier
-                        )
-                    }
-                    Row {
-                        Spacer(Modifier.weight(1f))
-                        TextButton(text = Label.COPY) { clipboard.setText(AnnotatedString(exceptionText())) }
-                        FormRowSpacer()
-                        TextButton(text = Label.QUIT) { quit = true; onClose() }
-                        FormRowSpacer()
-                        TextButton(text = Label.REOPEN, onClick = onClose)
+                val windowContext = WindowContext.Compose(window)
+                CompositionLocalProvider(LocalWindowContext provides windowContext) {
+                    Column(
+                        modifier = Modifier.fillMaxSize().background(Theme.studio.backgroundMedium)
+                            .padding(DIALOG_PADDING),
+                        verticalArrangement = Arrangement.spacedBy(DIALOG_PADDING)
+                    ) {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Text(value = "${Label.TITLE}:", modifier = labelModifier, textStyle = labelStyle)
+                            exception.message?.let { SelectableText(value = it, color = contentColor) }
+                        }
+                        Row(Modifier.weight(1f)) {
+                            Text(value = "${Label.TRACE}:", modifier = labelModifier, textStyle = labelStyle)
+                            SelectableText(
+                                value = exception.stackTraceToString(), color = contentColor, modifier = contentModifier
+                            )
+                        }
+                        Row {
+                            Spacer(Modifier.weight(1f))
+                            TextButton(text = Label.COPY) { clipboard.setText(AnnotatedString(exceptionText())) }
+                            FormRowSpacer()
+                            TextButton(text = Label.QUIT) { quit = true; onClose() }
+                            FormRowSpacer()
+                            TextButton(text = Label.REOPEN, onClick = onClose)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## What is the goal of this PR?

We have fixed a bug where error windows were not provided window contexts and crashed before being able to show the error.

## What are the changes implemented in this PR?

We provide a windowContext to the CompositionLocalProvider in the event of an error window being created.
