### PR TITLE
Bump Compose, rules_kotlin

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -24,7 +24,6 @@ load("@vaticle_bazel_distribution//common/tgz2zip:rules.bzl", "tgz2zip")
 load("@vaticle_bazel_distribution//github:rules.bzl", "deploy_github")
 load("@vaticle_bazel_distribution//brew:rules.bzl", "deploy_brew")
 load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_library")
-load("@io_bazel_rules_kotlin//kotlin:core.bzl", "kt_compiler_plugin")
 load("@io_bazel_rules_kotlin//kotlin/internal:toolchains.bzl", "define_kt_toolchain")
 load("@vaticle_bazel_distribution//platform/jvm:rules.bzl", "assemble_jvm_platform")
 load("@vaticle_typedb_common//test:rules.bzl", "native_typedb_artifact")
@@ -34,7 +33,7 @@ package(default_visibility = ["//test/integration:__subpackages__"])
 kt_jvm_library(
     name = "studio",
     srcs = glob(["*.kt"]),
-    plugins = ["//:org_jetbrains_compose_compiler_plugin"],
+    plugins = ["@vaticle_dependencies//builder/compose:compiler_plugin"],
     deps = [
         "//module/connection:connection",
         "//module/preference:preference",
@@ -70,16 +69,6 @@ kt_jvm_library(
     ],
     resources = ["//resources/icons/vaticle:vaticle-bot-32px"],
     tags = ["maven_coordinates=com.vaticle.typedb:typedb-studio:{pom_version}"],
-)
-
-kt_compiler_plugin(
-    name = "org_jetbrains_compose_compiler_plugin",
-    id = "jetbrains.compose.compiler",
-    target_embedded_compiler = True,
-    visibility = ["//visibility:public"],
-    deps = [
-        "@maven//:org_jetbrains_compose_compiler_compiler",
-    ],
 )
 
 load("@io_bazel_rules_kotlin//kotlin:core.bzl", "define_kt_toolchain")

--- a/BUILD
+++ b/BUILD
@@ -82,6 +82,14 @@ kt_compiler_plugin(
     ],
 )
 
+load("@io_bazel_rules_kotlin//kotlin:core.bzl", "define_kt_toolchain")
+define_kt_toolchain(
+    name = "kotlin_toolchain_strict_deps",
+    api_version = "1.7",
+    language_version = "1.7",
+    experimental_strict_kotlin_deps = "error",
+)
+
 java_binary(
     name = "studio-bin-mac",
     main_class = "com.vaticle.typedb.studio.Studio",

--- a/BUILD
+++ b/BUILD
@@ -202,6 +202,7 @@ deploy_brew(
     formula = "//config/brew:typedb-studio.rb",
 #    checksum = "//:checksum",
     version_file = "//:VERSION",
+    type = "cask",
 )
 
 checkstyle_test(

--- a/BUILD
+++ b/BUILD
@@ -16,14 +16,15 @@
 #
 
 load("//:deployment.bzl", deployment_github = "deployment")
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_binary", "kt_jvm_library")
 load("@rules_pkg//:pkg.bzl", "pkg_zip")
 load("@vaticle_dependencies//distribution:deployment.bzl", "deployment")
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
-load("@vaticle_bazel_distribution//common:rules.bzl", "checksum", "assemble_targz", "assemble_zip", "java_deps", "assemble_versioned")
+load("@vaticle_bazel_distribution//common:rules.bzl", "assemble_targz", "assemble_versioned", "assemble_zip", "checksum", "java_deps")
 load("@vaticle_bazel_distribution//common/tgz2zip:rules.bzl", "tgz2zip")
 load("@vaticle_bazel_distribution//github:rules.bzl", "deploy_github")
 load("@vaticle_bazel_distribution//brew:rules.bzl", "deploy_brew")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:core.bzl", "kt_compiler_plugin")
 load("@io_bazel_rules_kotlin//kotlin/internal:toolchains.bzl", "define_kt_toolchain")
 load("@vaticle_bazel_distribution//platform/jvm:rules.bzl", "assemble_jvm_platform")
 load("@vaticle_typedb_common//test:rules.bzl", "native_typedb_artifact")
@@ -33,7 +34,7 @@ package(default_visibility = ["//test/integration:__subpackages__"])
 kt_jvm_library(
     name = "studio",
     srcs = glob(["*.kt"]),
-    kotlin_compiler_plugin = "@org_jetbrains_compose_compiler//file",
+    plugins = ["//:org_jetbrains_compose_compiler_plugin"],
     deps = [
         "//module/connection:connection",
         "//module/preference:preference",
@@ -69,6 +70,16 @@ kt_jvm_library(
     ],
     resources = ["//resources/icons/vaticle:vaticle-bot-32px"],
     tags = ["maven_coordinates=com.vaticle.typedb:typedb-studio:{pom_version}"],
+)
+
+kt_compiler_plugin(
+    name = "org_jetbrains_compose_compiler_plugin",
+    id = "jetbrains.compose.compiler",
+    target_embedded_compiler = True,
+    visibility = ["//visibility:public"],
+    deps = [
+        "@maven//:org_jetbrains_compose_compiler_compiler",
+    ],
 )
 
 java_binary(
@@ -183,7 +194,6 @@ deploy_brew(
     formula = "//config/brew:typedb-studio.rb",
 #    checksum = "//:checksum",
     version_file = "//:VERSION",
-    type = "cask",
 )
 
 checkstyle_test(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -44,8 +44,14 @@ pip_install(
 # Load Kotlin
 load("@vaticle_dependencies//builder/kotlin:deps.bzl", kotlin_deps = "deps")
 kotlin_deps()
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kotlin_repositories", "kt_register_toolchains")
-kotlin_repositories()
+load("@io_bazel_rules_kotlin//kotlin:repositories.bzl", "kotlin_repositories", "kotlinc_version")
+kotlin_repositories(
+    compiler_release = kotlinc_version(
+        release = "1.7.20",
+        sha256 = "5e3c8d0f965410ff12e90d6f8dc5df2fc09fd595a684d514616851ce7e94ae7d"
+    )
+)
+load("@io_bazel_rules_kotlin//kotlin:core.bzl", "kt_register_toolchains")
 kt_register_toolchains()
 
 # Load //builder/antlr (required by typedb_client_java > typeql)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -53,6 +53,7 @@ kotlin_repositories(
 )
 load("@io_bazel_rules_kotlin//kotlin:core.bzl", "kt_register_toolchains")
 kt_register_toolchains()
+register_toolchains("//:kotlin_toolchain_strict_deps")
 
 # Load //builder/antlr (required by typedb_client_java > typeql)
 load("@vaticle_dependencies//builder/antlr:deps.bzl", antlr_deps = "deps", "antlr_version")

--- a/dependencies/maven/artifacts.bzl
+++ b/dependencies/maven/artifacts.bzl
@@ -21,6 +21,7 @@ artifacts = [
     "io.github.microutils:kotlin-logging-jvm",
     "junit:junit",
     "org.antlr:antlr4-runtime",
+    "org.jetbrains.compose.compiler:compiler",
     "org.jetbrains.compose.animation:animation-core-desktop",
     "org.jetbrains.compose.desktop:desktop-jvm",
     "org.jetbrains.compose.foundation:foundation-desktop",

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -20,8 +20,8 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
-        remote = "https://github.com/jamesreprise/vaticle-dependencies",
-        commit = "93221d338cc354f480185c39b27651da5f52cab7",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        remote = "https://github.com/vaticle/dependencies",
+        commit = "812da3752022e7f1529b1e445c38fb8b11239c56",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_force_graph():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,7 +21,7 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/jamesreprise/vaticle-dependencies",
-        commit = "2eb4482e8654517c232eac07e7fdcd39c94ff807",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "1e9701659f5f61743cfbad9f4c8859c6ce573759",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_force_graph():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,7 +21,7 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/jamesreprise/vaticle-dependencies",
-        commit = "9772f7b48932e0e859d74668b1004df10d29fc0d",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "4cd5e13bd1f5591cab6baf5e6317554a7eb4d55a",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_force_graph():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,7 +21,7 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/jamesreprise/vaticle-dependencies",
-        commit = "2f382ce387b826ae0051c779a4af8cbfb67fe571",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "9772f7b48932e0e859d74668b1004df10d29fc0d",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_force_graph():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,7 +21,7 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/jamesreprise/vaticle-dependencies",
-        commit = "4cd5e13bd1f5591cab6baf5e6317554a7eb4d55a",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "3e066389d30a6a5f17f908921d43e495eaca7861",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_force_graph():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,7 +21,7 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/jamesreprise/vaticle-dependencies",
-        commit = "3e066389d30a6a5f17f908921d43e495eaca7861",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "93221d338cc354f480185c39b27651da5f52cab7",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_force_graph():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,7 +21,7 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/jamesreprise/vaticle-dependencies",
-        commit = "dfb040f57793485add4fa1bf66537521b62a9a0d",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "2eb4482e8654517c232eac07e7fdcd39c94ff807",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_force_graph():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -20,8 +20,8 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
-        remote = "https://github.com/vaticle/dependencies",
-        commit = "5be6d949ca1e04e4179ea6acb3432be713b9dfb8",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        remote = "https://github.com/jamesreprise/vaticle-dependencies",
+        commit = "dfb040f57793485add4fa1bf66537521b62a9a0d",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_force_graph():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,7 +21,7 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/jamesreprise/vaticle-dependencies",
-        commit = "1e9701659f5f61743cfbad9f4c8859c6ce573759",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "2f382ce387b826ae0051c779a4af8cbfb67fe571",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_force_graph():

--- a/framework/common/BUILD
+++ b/framework/common/BUILD
@@ -16,7 +16,7 @@
 #
 
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library", "kt_jvm_test")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library", "kt_jvm_test")
 
 package(default_visibility = [
     "//module:__subpackages__",
@@ -28,7 +28,7 @@ package(default_visibility = [
 kt_jvm_library(
     name = "common",
     srcs = glob(["*.kt", "*/*.kt"], exclude = ["*/*Test.kt"]),
-    kotlin_compiler_plugin = "@org_jetbrains_compose_compiler//file",
+    plugins = ["//:org_jetbrains_compose_compiler_plugin"],
     deps = [
         "//service/common:common",
 

--- a/framework/common/BUILD
+++ b/framework/common/BUILD
@@ -28,7 +28,7 @@ package(default_visibility = [
 kt_jvm_library(
     name = "common",
     srcs = glob(["*.kt", "*/*.kt"], exclude = ["*/*Test.kt"]),
-    plugins = ["//:org_jetbrains_compose_compiler_plugin"],
+    plugins = ["@vaticle_dependencies//builder/compose:compiler_plugin"],
     deps = [
         "//service/common:common",
 

--- a/framework/common/Util.kt
+++ b/framework/common/Util.kt
@@ -54,8 +54,12 @@ object Util {
     }
 
     fun mousePoint(windowCtx: WindowContext, titleBarHeight: Dp): Point {
-        val raw = MouseInfo.getPointerInfo().location
-        return Point(raw.x - windowCtx.x, raw.y - windowCtx.y - titleBarHeight.value.toInt())
+        return if (windowCtx is WindowContext.Compose) {
+            val raw = MouseInfo.getPointerInfo().location
+            Point(raw.x - windowCtx.x, raw.y - windowCtx.y - titleBarHeight.value.toInt())
+        } else {
+            Point(0, 0)
+        }
     }
 
     fun isMouseHover(area: Rect, window: WindowContext, titleBarHeight: Dp): Boolean {

--- a/framework/editor/BUILD
+++ b/framework/editor/BUILD
@@ -26,7 +26,7 @@ package(default_visibility = [
 kt_jvm_library(
     name = "editor",
     srcs = glob(["*.kt"]),
-    plugins = ["//:org_jetbrains_compose_compiler_plugin"],
+    plugins = ["@vaticle_dependencies//builder/compose:compiler_plugin"],
     deps = [
         "//service/common:common",
         "//service/connection:connection",

--- a/framework/editor/BUILD
+++ b/framework/editor/BUILD
@@ -16,7 +16,7 @@
 #
 
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 package(default_visibility = [
     "//module/project:__pkg__",
@@ -26,7 +26,7 @@ package(default_visibility = [
 kt_jvm_library(
     name = "editor",
     srcs = glob(["*.kt"]),
-    kotlin_compiler_plugin = "@org_jetbrains_compose_compiler//file",
+    plugins = ["//:org_jetbrains_compose_compiler_plugin"],
     deps = [
         "//service/common:common",
         "//service/connection:connection",

--- a/framework/editor/TextEditor.kt
+++ b/framework/editor/TextEditor.kt
@@ -88,11 +88,10 @@ import java.awt.event.MouseEvent.BUTTON1
 import kotlin.math.ceil
 import kotlin.math.log10
 import kotlin.math.roundToInt
-import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.delay
 import mu.KotlinLogging
 
-@OptIn(kotlin.time.ExperimentalTime::class)
 object TextEditor {
 
     private const val LINE_HEIGHT = 1.56f
@@ -102,7 +101,7 @@ object TextEditor {
     private val RIGHT_PADDING = 32.dp
     private val DEFAULT_FONT_WIDTH = 7.dp
     private val CURSOR_LINE_PADDING = 0.dp
-    private val BLINKING_FREQUENCY = Duration.milliseconds(500)
+    private val BLINKING_FREQUENCY = 500.milliseconds
     private val END_OF_FILE_SPACE = 100.dp
     private val MAX_LINE_MIN_WIDTH: Dp = 100_000.dp // we need this cause Compose can't render components too large
     private val LOGGER = KotlinLogging.logger {}

--- a/framework/editor/TextProcessor.kt
+++ b/framework/editor/TextProcessor.kt
@@ -40,7 +40,7 @@ import java.util.concurrent.BlockingQueue
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.math.floor
-import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -425,13 +425,12 @@ internal interface TextProcessor {
             target.updateCursor(insertion.selection().max, false)
         }
 
-        @OptIn(kotlin.time.ExperimentalTime::class)
         private fun queueChangeStack(change: TextChange) {
             redoStack.clear()
             changeQueue.put(change)
             changeCount.incrementAndGet()
             coroutines.launch {
-                delay(Duration.milliseconds(TYPING_WINDOW_MILLIS))
+                delay(TYPING_WINDOW_MILLIS.milliseconds)
                 if (changeCount.decrementAndGet() == 0) drainAndBatchChanges(isFinalChange = true)
             }
         }

--- a/framework/editor/TextToolbar.kt
+++ b/framework/editor/TextToolbar.kt
@@ -63,13 +63,12 @@ import com.vaticle.typedb.studio.framework.material.Separator
 import com.vaticle.typedb.studio.framework.material.Tooltip
 import com.vaticle.typedb.studio.service.common.util.Label
 import java.util.concurrent.atomic.AtomicInteger
-import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
-@OptIn(kotlin.time.ExperimentalTime::class)
 object TextToolbar {
 
     private val INPUT_MAX_WIDTH = 740.dp
@@ -81,7 +80,7 @@ object TextToolbar {
     private val BUTTON_AREA_WIDTH = 300.dp
     private val BUTTON_HEIGHT = 23.dp
     private val BUTTON_SPACING = 4.dp
-    private val FIND_TEXT_DELAY = Duration.milliseconds(200)
+    private val FIND_TEXT_DELAY = 200.milliseconds
 
     internal class State(
         private val finder: TextFinder,

--- a/framework/editor/highlighter/BUILD
+++ b/framework/editor/highlighter/BUILD
@@ -23,7 +23,7 @@ package(default_visibility = ["//framework/editor:__pkg__"])
 kt_jvm_library(
     name = "highlighter",
     srcs = glob(["*.kt"]),
-    plugins = ["//:org_jetbrains_compose_compiler_plugin"],
+    plugins = ["@vaticle_dependencies//builder/compose:compiler_plugin"],
     deps = [
         "//service/common:common",
         "//service/project:project",

--- a/framework/editor/highlighter/BUILD
+++ b/framework/editor/highlighter/BUILD
@@ -16,14 +16,14 @@
 #
 
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 package(default_visibility = ["//framework/editor:__pkg__"])
 
 kt_jvm_library(
     name = "highlighter",
     srcs = glob(["*.kt"]),
-    kotlin_compiler_plugin = "@org_jetbrains_compose_compiler//file",
+    plugins = ["//:org_jetbrains_compose_compiler_plugin"],
     deps = [
         "//service/common:common",
         "//service/project:project",

--- a/framework/editor/highlighter/common/BUILD
+++ b/framework/editor/highlighter/common/BUILD
@@ -16,14 +16,14 @@
 #
 
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 package(default_visibility = ["//framework/editor/highlighter:__subpackages__"])
 
 kt_jvm_library(
     name = "common",
     srcs = glob(["*.kt"]),
-    kotlin_compiler_plugin = "@org_jetbrains_compose_compiler//file",
+    plugins = ["//:org_jetbrains_compose_compiler_plugin"],
     deps = [
         "//framework/common:common",
 

--- a/framework/editor/highlighter/common/BUILD
+++ b/framework/editor/highlighter/common/BUILD
@@ -23,7 +23,7 @@ package(default_visibility = ["//framework/editor/highlighter:__subpackages__"])
 kt_jvm_library(
     name = "common",
     srcs = glob(["*.kt"]),
-    plugins = ["//:org_jetbrains_compose_compiler_plugin"],
+    plugins = ["@vaticle_dependencies//builder/compose:compiler_plugin"],
     deps = [
         "//framework/common:common",
 

--- a/framework/editor/highlighter/typeql/BUILD
+++ b/framework/editor/highlighter/typeql/BUILD
@@ -23,7 +23,7 @@ package(default_visibility = ["//framework/editor/highlighter:__pkg__"])
 kt_jvm_library(
     name = "typeql",
     srcs = glob(["*.kt"]),
-    plugins = ["//:org_jetbrains_compose_compiler_plugin"],
+    plugins = ["@vaticle_dependencies//builder/compose:compiler_plugin"],
     deps = [
         "//framework/editor/highlighter/common:common",
 

--- a/framework/editor/highlighter/typeql/BUILD
+++ b/framework/editor/highlighter/typeql/BUILD
@@ -16,14 +16,14 @@
 #
 
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 package(default_visibility = ["//framework/editor/highlighter:__pkg__"])
 
 kt_jvm_library(
     name = "typeql",
     srcs = glob(["*.kt"]),
-    kotlin_compiler_plugin = "@org_jetbrains_compose_compiler//file",
+    plugins = ["//:org_jetbrains_compose_compiler_plugin"],
     deps = [
         "//framework/editor/highlighter/common:common",
 

--- a/framework/graph/BUILD
+++ b/framework/graph/BUILD
@@ -26,7 +26,7 @@ package(default_visibility = [
 kt_jvm_library(
     name = "graph",
     srcs = glob(["*.kt"]),
-    plugins = ["//:org_jetbrains_compose_compiler_plugin"],
+    plugins = ["@vaticle_dependencies//builder/compose:compiler_plugin"],
     deps = [
         "//service/common:common",
         "//service/connection:connection",

--- a/framework/graph/BUILD
+++ b/framework/graph/BUILD
@@ -16,7 +16,7 @@
 #
 
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 package(default_visibility = [
     "//module/project:__pkg__",
@@ -26,7 +26,7 @@ package(default_visibility = [
 kt_jvm_library(
     name = "graph",
     srcs = glob(["*.kt"]),
-    kotlin_compiler_plugin = "@org_jetbrains_compose_compiler//file",
+    plugins = ["//:org_jetbrains_compose_compiler_plugin"],
     deps = [
         "//service/common:common",
         "//service/connection:connection",

--- a/framework/material/BUILD
+++ b/framework/material/BUILD
@@ -16,7 +16,7 @@
 #
 
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library", "kt_jvm_test")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library", "kt_jvm_test")
 
 package(default_visibility = [
     "//module:__subpackages__",
@@ -28,7 +28,7 @@ package(default_visibility = [
 kt_jvm_library(
     name = "material",
     srcs = glob(["*.kt", "*/*.kt"], exclude = ["*/*Test.kt"]),
-    kotlin_compiler_plugin = "@org_jetbrains_compose_compiler//file",
+    plugins = ["//:org_jetbrains_compose_compiler_plugin"],
     deps = [
         "//service/common:common",
         "//service/page:page",

--- a/framework/material/BUILD
+++ b/framework/material/BUILD
@@ -28,7 +28,7 @@ package(default_visibility = [
 kt_jvm_library(
     name = "material",
     srcs = glob(["*.kt", "*/*.kt"], exclude = ["*/*Test.kt"]),
-    plugins = ["//:org_jetbrains_compose_compiler_plugin"],
+    plugins = ["@vaticle_dependencies//builder/compose:compiler_plugin"],
     deps = [
         "//service/common:common",
         "//service/page:page",

--- a/framework/material/Navigator.kt
+++ b/framework/material/Navigator.kt
@@ -94,13 +94,12 @@ import java.lang.Integer.min
 import java.util.LinkedList
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.math.floor
-import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import mu.KotlinLogging
 
-@OptIn(kotlin.time.ExperimentalTime::class)
 object Navigator {
 
     sealed class Behaviour(val clicksToOpenItem: Int, val itemsAreFocusable: Boolean) {
@@ -109,7 +108,7 @@ object Navigator {
     }
 
     val ITEM_HEIGHT = 26.dp
-    private val LIVE_UPDATE_REFRESH_RATE = Duration.seconds(1)
+    private val LIVE_UPDATE_REFRESH_RATE = 1.seconds
     private val ICON_WIDTH = 20.dp
     private val TEXT_SPACING = 4.dp
     private val AREA_PADDING = 8.dp

--- a/framework/material/Tooltip.kt
+++ b/framework/material/Tooltip.kt
@@ -59,16 +59,15 @@ import com.vaticle.typedb.studio.service.common.util.Label
 import java.awt.MouseInfo
 import java.net.URL
 import java.util.concurrent.atomic.AtomicBoolean
-import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
-@OptIn(kotlin.time.ExperimentalTime::class)
 object Tooltip {
 
-    private val TOOLTIP_DELAY = Duration.Companion.milliseconds(800)
+    private val TOOLTIP_DELAY = 800.milliseconds
     private val TOOLTIP_WIDTH = 250.dp
     private val TOOLTIP_OFFSET = 24.dp
     private val TOOLTIP_SPACE = 8.dp

--- a/framework/output/BUILD
+++ b/framework/output/BUILD
@@ -16,7 +16,7 @@
 #
 
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 package(default_visibility = [
     "//module/project:__pkg__",
@@ -27,7 +27,7 @@ package(default_visibility = [
 kt_jvm_library(
     name = "output",
     srcs = glob(["*.kt"]),
-    kotlin_compiler_plugin = "@org_jetbrains_compose_compiler//file",
+    plugins = ["//:org_jetbrains_compose_compiler_plugin"],
     deps = [
         "//service/common:common",
         "//service/connection:connection",

--- a/framework/output/BUILD
+++ b/framework/output/BUILD
@@ -27,7 +27,7 @@ package(default_visibility = [
 kt_jvm_library(
     name = "output",
     srcs = glob(["*.kt"]),
-    plugins = ["//:org_jetbrains_compose_compiler_plugin"],
+    plugins = ["@vaticle_dependencies//builder/compose:compiler_plugin"],
     deps = [
         "//service/common:common",
         "//service/connection:connection",

--- a/framework/output/LogOutput.kt
+++ b/framework/output/LogOutput.kt
@@ -131,12 +131,12 @@ internal class LogOutput constructor(
         while (isCollecting.get()) {
             delay(duration)
             if (!isCollecting.get()) return@launchAndHandle
-            val sinceLastResponse = System.currentTimeMillis() - lastOutputTime.get()
-            if (sinceLastResponse >= RUNNING_INDICATOR_DELAY.inWholeMilliseconds) {
+            val timeSinceLastResponse = System.currentTimeMillis() - lastOutputTime.get()
+            if (timeSinceLastResponse >= RUNNING_INDICATOR_DELAY.inWholeMilliseconds) {
                 output(INFO, "...")
                 duration = RUNNING_INDICATOR_DELAY
             } else {
-                duration = RUNNING_INDICATOR_DELAY - sinceLastResponse.milliseconds
+                duration = RUNNING_INDICATOR_DELAY - timeSinceLastResponse.milliseconds
             }
         }
     }

--- a/framework/output/LogOutput.kt
+++ b/framework/output/LogOutput.kt
@@ -57,13 +57,13 @@ import com.vaticle.typeql.lang.common.util.Strings
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 import java.util.stream.Collectors
-import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import mu.KotlinLogging
 
-@OptIn(kotlin.time.ExperimentalTime::class)
 internal class LogOutput constructor(
     private val editorState: TextEditor.State,
     private val transactionState: TransactionState,
@@ -72,7 +72,7 @@ internal class LogOutput constructor(
 
     companion object {
         private val END_OF_OUTPUT_SPACE = 20.dp
-        private val RUNNING_INDICATOR_DELAY = Duration.seconds(3)
+        private val RUNNING_INDICATOR_DELAY = 3.seconds
         private val LOGGER = KotlinLogging.logger {}
 
         @Composable
@@ -136,7 +136,7 @@ internal class LogOutput constructor(
                 output(INFO, "...")
                 duration = RUNNING_INDICATOR_DELAY
             } else {
-                duration = RUNNING_INDICATOR_DELAY - Duration.milliseconds(sinceLastResponse)
+                duration = RUNNING_INDICATOR_DELAY - sinceLastResponse.milliseconds
             }
         }
     }

--- a/framework/output/RunOutputGroup.kt
+++ b/framework/output/RunOutputGroup.kt
@@ -39,12 +39,13 @@ import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit.MILLISECONDS
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.ExperimentalTime
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import mu.KotlinLogging
 
-@OptIn(kotlin.time.ExperimentalTime::class)
 internal class RunOutputGroup constructor(
     private val runner: QueryRunner,
     private val logOutput: LogOutput
@@ -65,7 +66,7 @@ internal class RunOutputGroup constructor(
 
     companion object {
         private const val COUNT_DOWN_LATCH_PERIOD_MS: Long = 50
-        private val CONSUMER_PERIOD_MS = Duration.milliseconds(33) // 30 FPS
+        private val CONSUMER_PERIOD_MS = 33.milliseconds // 30 FPS
         private val LOGGER = KotlinLogging.logger {}
 
         @Composable
@@ -96,16 +97,13 @@ internal class RunOutputGroup constructor(
     }
 
     private fun publishQueryResponseTime() = runner.startTime?.let { startTime ->
-        val duration = (runner.endTime ?: System.currentTimeMillis()) - startTime
-        Service.status.publish(
-            QUERY_RESPONSE_TIME,
-            Duration.milliseconds(duration).toString()
-        )
+            val duration = (runner.endTime ?: System.currentTimeMillis()) - startTime
+            Service.status.publish(QUERY_RESPONSE_TIME, duration.milliseconds.toString())
     } ?: Unit
 
     private fun publishOutputResponseTime() = runner.endTime?.let { queryEndTime ->
-        val duration = (endTime ?: System.currentTimeMillis()) - queryEndTime
-        Service.status.publish(OUTPUT_RESPONSE_TIME, Duration.milliseconds(duration).toString())
+            val duration = (endTime ?: System.currentTimeMillis()) - queryEndTime
+            Service.status.publish(OUTPUT_RESPONSE_TIME, duration.milliseconds.toString())
     } ?: Unit
 
     private fun clearStatus() {

--- a/framework/output/RunOutputGroup.kt
+++ b/framework/output/RunOutputGroup.kt
@@ -38,9 +38,7 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit.MILLISECONDS
 import java.util.concurrent.atomic.AtomicInteger
-import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.ExperimentalTime
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -97,13 +95,13 @@ internal class RunOutputGroup constructor(
     }
 
     private fun publishQueryResponseTime() = runner.startTime?.let { startTime ->
-            val duration = (runner.endTime ?: System.currentTimeMillis()) - startTime
-            Service.status.publish(QUERY_RESPONSE_TIME, duration.milliseconds.toString())
+            val responseTime = (runner.endTime ?: System.currentTimeMillis()) - startTime
+            Service.status.publish(QUERY_RESPONSE_TIME, responseTime.milliseconds.toString())
     } ?: Unit
 
     private fun publishOutputResponseTime() = runner.endTime?.let { queryEndTime ->
-            val duration = (endTime ?: System.currentTimeMillis()) - queryEndTime
-            Service.status.publish(OUTPUT_RESPONSE_TIME, duration.milliseconds.toString())
+            val responseTime = (endTime ?: System.currentTimeMillis()) - queryEndTime
+            Service.status.publish(OUTPUT_RESPONSE_TIME, responseTime.milliseconds.toString())
     } ?: Unit
 
     private fun clearStatus() {

--- a/module/BUILD
+++ b/module/BUILD
@@ -16,14 +16,14 @@
 #
 
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 package(default_visibility = ["//:__pkg__"])
 
 kt_jvm_library(
     name = "module",
     srcs = glob(["*.kt"]),
-    kotlin_compiler_plugin = "@org_jetbrains_compose_compiler//file",
+    plugins = ["//:org_jetbrains_compose_compiler_plugin"],
     deps = [
         "//module/connection:connection",
         "//service/common:common",

--- a/module/BUILD
+++ b/module/BUILD
@@ -23,7 +23,7 @@ package(default_visibility = ["//:__pkg__"])
 kt_jvm_library(
     name = "module",
     srcs = glob(["*.kt"]),
-    plugins = ["//:org_jetbrains_compose_compiler_plugin"],
+    plugins = ["@vaticle_dependencies//builder/compose:compiler_plugin"],
     deps = [
         "//module/connection:connection",
         "//service/common:common",

--- a/module/connection/BUILD
+++ b/module/connection/BUILD
@@ -27,7 +27,7 @@ package(default_visibility = [
 kt_jvm_library(
     name = "connection",
     srcs = glob(["*.kt"]),
-    plugins = ["//:org_jetbrains_compose_compiler_plugin"],
+    plugins = ["@vaticle_dependencies//builder/compose:compiler_plugin"],
     deps = [
         "//service/common:common",
         "//service/connection:connection",

--- a/module/connection/BUILD
+++ b/module/connection/BUILD
@@ -16,7 +16,7 @@
 #
 
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 package(default_visibility = [
     "//framework:__subpackages__",
@@ -27,7 +27,7 @@ package(default_visibility = [
 kt_jvm_library(
     name = "connection",
     srcs = glob(["*.kt"]),
-    kotlin_compiler_plugin = "@org_jetbrains_compose_compiler//file",
+    plugins = ["//:org_jetbrains_compose_compiler_plugin"],
     deps = [
         "//service/common:common",
         "//service/connection:connection",

--- a/module/preference/BUILD
+++ b/module/preference/BUILD
@@ -27,7 +27,7 @@ package(default_visibility = [
 kt_jvm_library(
     name = "preference",
     srcs = glob(["*.kt"]),
-    plugins = ["//:org_jetbrains_compose_compiler_plugin"],
+    plugins = ["@vaticle_dependencies//builder/compose:compiler_plugin"],
     deps = [
         "//service/common:common",
         "//service/connection:connection",

--- a/module/preference/BUILD
+++ b/module/preference/BUILD
@@ -16,7 +16,7 @@
 #
 
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 package(default_visibility = [
     "//framework:__subpackages__",
@@ -27,7 +27,7 @@ package(default_visibility = [
 kt_jvm_library(
     name = "preference",
     srcs = glob(["*.kt"]),
-    kotlin_compiler_plugin = "@org_jetbrains_compose_compiler//file",
+    plugins = ["//:org_jetbrains_compose_compiler_plugin"],
     deps = [
         "//service/common:common",
         "//service/connection:connection",

--- a/module/project/BUILD
+++ b/module/project/BUILD
@@ -16,7 +16,7 @@
 #
 
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 package(default_visibility = [
     "//framework:__pkg__",
@@ -26,7 +26,7 @@ package(default_visibility = [
 kt_jvm_library(
     name = "project",
     srcs = glob(["*.kt"]),
-    kotlin_compiler_plugin = "@org_jetbrains_compose_compiler//file",
+    plugins = ["//:org_jetbrains_compose_compiler_plugin"],
     deps = [
         "//service/common:common",
         "//service/project:project",

--- a/module/project/BUILD
+++ b/module/project/BUILD
@@ -26,7 +26,7 @@ package(default_visibility = [
 kt_jvm_library(
     name = "project",
     srcs = glob(["*.kt"]),
-    plugins = ["//:org_jetbrains_compose_compiler_plugin"],
+    plugins = ["@vaticle_dependencies//builder/compose:compiler_plugin"],
     deps = [
         "//service/common:common",
         "//service/project:project",

--- a/module/role/BUILD
+++ b/module/role/BUILD
@@ -16,7 +16,7 @@
 #
 
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 package(default_visibility = [
     "//framework:__pkg__",
@@ -26,7 +26,7 @@ package(default_visibility = [
 kt_jvm_library(
     name = "role",
     srcs = glob(["*.kt"]),
-    kotlin_compiler_plugin = "@org_jetbrains_compose_compiler//file",
+    plugins = ["//:org_jetbrains_compose_compiler_plugin"],
     deps = [
         "//service/common:common",
         "//framework/common:common",

--- a/module/role/BUILD
+++ b/module/role/BUILD
@@ -26,7 +26,7 @@ package(default_visibility = [
 kt_jvm_library(
     name = "role",
     srcs = glob(["*.kt"]),
-    plugins = ["//:org_jetbrains_compose_compiler_plugin"],
+    plugins = ["@vaticle_dependencies//builder/compose:compiler_plugin"],
     deps = [
         "//service/common:common",
         "//framework/common:common",

--- a/module/rule/BUILD
+++ b/module/rule/BUILD
@@ -16,7 +16,7 @@
 #
 
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 package(default_visibility = [
     "//framework:__pkg__",
@@ -26,7 +26,7 @@ package(default_visibility = [
 kt_jvm_library(
     name = "rule",
     srcs = glob(["*.kt"]),
-    kotlin_compiler_plugin = "@org_jetbrains_compose_compiler//file",
+    plugins = ["//:org_jetbrains_compose_compiler_plugin"],
     deps = [
         "//service/common:common",
         "//framework/common:common",

--- a/module/rule/BUILD
+++ b/module/rule/BUILD
@@ -26,7 +26,7 @@ package(default_visibility = [
 kt_jvm_library(
     name = "rule",
     srcs = glob(["*.kt"]),
-    plugins = ["//:org_jetbrains_compose_compiler_plugin"],
+    plugins = ["@vaticle_dependencies//builder/compose:compiler_plugin"],
     deps = [
         "//service/common:common",
         "//framework/common:common",

--- a/module/type/BUILD
+++ b/module/type/BUILD
@@ -16,7 +16,7 @@
 #
 
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 package(default_visibility = [
     "//framework:__pkg__",
@@ -26,7 +26,7 @@ package(default_visibility = [
 kt_jvm_library(
     name = "type",
     srcs = glob(["*.kt"]),
-    kotlin_compiler_plugin = "@org_jetbrains_compose_compiler//file",
+    plugins = ["//:org_jetbrains_compose_compiler_plugin"],
     deps = [
         "//service/common:common",
         "//service/connection:connection",

--- a/module/type/BUILD
+++ b/module/type/BUILD
@@ -26,7 +26,7 @@ package(default_visibility = [
 kt_jvm_library(
     name = "type",
     srcs = glob(["*.kt"]),
-    plugins = ["//:org_jetbrains_compose_compiler_plugin"],
+    plugins = ["@vaticle_dependencies//builder/compose:compiler_plugin"],
     deps = [
         "//service/common:common",
         "//service/connection:connection",

--- a/module/user/BUILD
+++ b/module/user/BUILD
@@ -16,7 +16,7 @@
 #
 
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 package(default_visibility = [
     "//:__pkg__",
@@ -26,7 +26,7 @@ package(default_visibility = [
 kt_jvm_library(
     name = "user",
     srcs = glob(["*.kt"]),
-    kotlin_compiler_plugin = "@org_jetbrains_compose_compiler//file",
+    plugins = ["//:org_jetbrains_compose_compiler_plugin"],
     tags = ["maven_coordinates=com.vaticle.typedb:typedb-studio-module-user:{pom_version}"],
     deps = [
         "//service",

--- a/module/user/BUILD
+++ b/module/user/BUILD
@@ -26,7 +26,7 @@ package(default_visibility = [
 kt_jvm_library(
     name = "user",
     srcs = glob(["*.kt"]),
-    plugins = ["//:org_jetbrains_compose_compiler_plugin"],
+    plugins = ["@vaticle_dependencies//builder/compose:compiler_plugin"],
     tags = ["maven_coordinates=com.vaticle.typedb:typedb-studio-module-user:{pom_version}"],
     deps = [
         "//service",

--- a/service/BUILD
+++ b/service/BUILD
@@ -16,7 +16,7 @@
 #
 
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 package(default_visibility = [
     "//module:__subpackages__",

--- a/service/common/BUILD
+++ b/service/common/BUILD
@@ -16,7 +16,7 @@
 #
 
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 package(default_visibility = [
     "//framework:__subpackages__",

--- a/service/common/NotificationService.kt
+++ b/service/common/NotificationService.kt
@@ -28,7 +28,7 @@ import com.vaticle.typedb.studio.service.common.util.Message.Companion.UNKNOWN
 import com.vaticle.typedb.studio.service.common.util.Message.System.Companion.UNEXPECTED_ERROR_IN_COROUTINE
 import java.util.concurrent.CompletableFuture
 import kotlin.coroutines.cancellation.CancellationException
-import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers.Default
 import kotlinx.coroutines.delay
@@ -47,9 +47,8 @@ class NotificationService {
     val isOpen: Boolean get() = queue.isNotEmpty()
     private val coroutines = CoroutineScope(Default)
 
-    @OptIn(kotlin.time.ExperimentalTime::class)
     companion object {
-        private val HIDE_DELAY = Duration.seconds(10)
+        private val HIDE_DELAY = 10.seconds
         private val LOGGER = KotlinLogging.logger {}
 
         fun <T> launchCompletableFuture(

--- a/service/connection/BUILD
+++ b/service/connection/BUILD
@@ -16,7 +16,7 @@
 #
 
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 package(default_visibility = [
     "//framework:__subpackages__",

--- a/service/page/BUILD
+++ b/service/page/BUILD
@@ -16,7 +16,7 @@
 #
 
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 package(default_visibility = [
     "//framework:__subpackages__",

--- a/service/project/BUILD
+++ b/service/project/BUILD
@@ -16,7 +16,7 @@
 #
 
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 package(default_visibility = [
     "//framework:__subpackages__",

--- a/service/project/FileState.kt
+++ b/service/project/FileState.kt
@@ -53,6 +53,7 @@ import kotlin.io.path.isWritable
 import kotlin.io.path.name
 import kotlin.io.path.relativeTo
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -65,9 +66,8 @@ class FileState internal constructor(
     projectSrv: ProjectService,
 ) : PathState(parent, path, Type.FILE, projectSrv), Pageable.Runnable {
 
-    @OptIn(kotlin.time.ExperimentalTime::class)
     companion object {
-        private val LIVE_UPDATE_REFRESH_RATE: Duration = Duration.seconds(1)
+        private val LIVE_UPDATE_REFRESH_RATE: Duration = 1.seconds
         private val LOGGER = KotlinLogging.logger {}
     }
 

--- a/service/project/Project.kt
+++ b/service/project/Project.kt
@@ -25,7 +25,7 @@ import java.nio.file.Path
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.io.path.exists
 import kotlin.io.path.isReadable
-import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -44,10 +44,9 @@ class Project internal constructor(val path: Path, private val projectSrv: Proje
     override val isExpandable: Boolean = true
     override val isBulkExpandable: Boolean = true
 
-    @OptIn(kotlin.time.ExperimentalTime::class)
     companion object {
         private val LOGGER = KotlinLogging.logger {}
-        private val WATCHER_REFRESH_RATE = Duration.seconds(1)
+        private val WATCHER_REFRESH_RATE = 1.seconds
     }
 
     override fun reloadEntries() {

--- a/service/schema/BUILD
+++ b/service/schema/BUILD
@@ -16,7 +16,7 @@
 #
 
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 package(default_visibility = [
     "//:__pkg__",

--- a/service/schema/SchemaService.kt
+++ b/service/schema/SchemaService.kt
@@ -49,7 +49,8 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
-import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -147,7 +148,7 @@ class SchemaService(
     internal val coroutines = CoroutineScope(Dispatchers.Default)
 
     companion object {
-        private val TX_IDLE_TIME = Duration.seconds(16)
+        private val TX_IDLE_TIME = 16.seconds
         private val LOGGER = KotlinLogging.logger {}
     }
 
@@ -318,7 +319,7 @@ class SchemaService(
             if (sinceLastUse >= TX_IDLE_TIME.inWholeMilliseconds) {
                 closeReadTx()
                 break
-            } else duration = TX_IDLE_TIME - Duration.milliseconds(sinceLastUse)
+            } else duration = TX_IDLE_TIME - sinceLastUse.milliseconds
         }
     }
 

--- a/service/schema/SchemaService.kt
+++ b/service/schema/SchemaService.kt
@@ -315,11 +315,11 @@ class SchemaService(
         var duration = TX_IDLE_TIME
         while (true) {
             delay(duration)
-            val sinceLastUse = System.currentTimeMillis() - lastTransactionUse.get()
-            if (sinceLastUse >= TX_IDLE_TIME.inWholeMilliseconds) {
+            val timeSinceLastUse = System.currentTimeMillis() - lastTransactionUse.get()
+            if (timeSinceLastUse >= TX_IDLE_TIME.inWholeMilliseconds) {
                 closeReadTx()
                 break
-            } else duration = TX_IDLE_TIME - sinceLastUse.milliseconds
+            } else duration = TX_IDLE_TIME - timeSinceLastUse.milliseconds
         }
     }
 

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -16,7 +16,7 @@
 #
 
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library", "kt_jvm_test")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library", "kt_jvm_test")
 load("@vaticle_typedb_common//test:rules.bzl", "typedb_kt_test")
 
 package(default_visibility = ["//:__pkg__"])
@@ -48,7 +48,7 @@ compose_test_libraries = [
 kt_jvm_library(
     name = "test-integration",
     srcs = ["IntegrationTest.kt"],
-    kotlin_compiler_plugin = "@org_jetbrains_compose_compiler//file",
+    plugins = ["//:org_jetbrains_compose_compiler_plugin"],
     runtime_deps = skiko_runtime_platform,
     deps = [
         "//:studio",

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -48,7 +48,7 @@ compose_test_libraries = [
 kt_jvm_library(
     name = "test-integration",
     srcs = ["IntegrationTest.kt"],
-    plugins = ["//:org_jetbrains_compose_compiler_plugin"],
+    plugins = ["@vaticle_dependencies//builder/compose:compiler_plugin"],
     runtime_deps = skiko_runtime_platform,
     deps = [
         "//:studio",

--- a/test/integration/common/BUILD
+++ b/test/integration/common/BUILD
@@ -16,7 +16,7 @@
 #
 
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 package(default_visibility = ["//test/integration:__pkg__"])
 
@@ -29,7 +29,7 @@ skiko_runtime_platform = select({
 kt_jvm_library(
     name = "common",
     srcs = glob(["*.kt"]),
-    kotlin_compiler_plugin = "@org_jetbrains_compose_compiler//file",
+    plugins = ["//:org_jetbrains_compose_compiler_plugin"],
     runtime_deps = skiko_runtime_platform,
     deps = [
         "//:studio",

--- a/test/integration/common/BUILD
+++ b/test/integration/common/BUILD
@@ -29,7 +29,7 @@ skiko_runtime_platform = select({
 kt_jvm_library(
     name = "common",
     srcs = glob(["*.kt"]),
-    plugins = ["//:org_jetbrains_compose_compiler_plugin"],
+    plugins = ["@vaticle_dependencies//builder/compose:compiler_plugin"],
     runtime_deps = skiko_runtime_platform,
     deps = [
         "//:studio",

--- a/test/integration/data/BUILD
+++ b/test/integration/data/BUILD
@@ -16,7 +16,7 @@
 #
 
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 package(default_visibility = ["//test/integration:__subpackages__"])
 
@@ -29,7 +29,7 @@ skiko_runtime_platform = select({
 kt_jvm_library(
     name = "paths",
     srcs = ["Paths.kt"],
-    kotlin_compiler_plugin = "@org_jetbrains_compose_compiler//file",
+    plugins = ["//:org_jetbrains_compose_compiler_plugin"],
     runtime_deps = skiko_runtime_platform,
     deps = [
         # External Maven Dependencies

--- a/test/integration/data/BUILD
+++ b/test/integration/data/BUILD
@@ -29,7 +29,7 @@ skiko_runtime_platform = select({
 kt_jvm_library(
     name = "paths",
     srcs = ["Paths.kt"],
-    plugins = ["//:org_jetbrains_compose_compiler_plugin"],
+    plugins = ["@vaticle_dependencies//builder/compose:compiler_plugin"],
     runtime_deps = skiko_runtime_platform,
     deps = [
         # External Maven Dependencies


### PR DESCRIPTION
## What is the goal of this PR?

We want to upgrade to the latest versions of Compose Multiplatform and Kotlin for increased performance and functionality.

## What are the changes implemented in this PR?

We've bumped `rules_kotlin`, which now provides its own method for importing compiler plugins.

We've also bumped Compose for improved stability and test reliability.

In order to allow for the Studio tests to run smoothly in CI, we've also added a check to before invoking `java.awt.MouseInfo.getPointerInfo` that runs the aforementioned function depending on whether our `WindowContext` is a `WindowContext.Test` or a `WindowContext.Compose`. In the former, we don't invoke this function as it would cause a runtime error.

## Note
We must merge https://github.com/vaticle/dependencies/pull/401 and update the dependencies locally accordingly before merging this PR.

Closes https://github.com/vaticle/typedb-studio/issues/613