### PR TITLE
Toggling infer no longer toggles explanations

### DIFF
--- a/state/connection/TransactionState.kt
+++ b/state/connection/TransactionState.kt
@@ -98,7 +98,7 @@ class TransactionState constructor(
         else try {
             val options = typeDBOptions()
                 .infer(infer.value)
-                .explain(infer.value)
+                .explain(explain.value)
                 .transactionTimeoutMillis(ONE_HOUR_IN_MILLS)
             session.transaction(type, options)!!.apply {
                 onClose { close(TRANSACTION_CLOSED_ON_SERVER, it?.message ?: UNKNOWN) }


### PR DESCRIPTION
## What is the goal of this PR?

When we run a query, we automatically include `TypeDBOptions` given the state of the toolbar. Currently, we derive the value of `explain` for `TypeDBOptions` from `infer`. We should derive it from `explain`.

## What are the changes implemented in this PR?

We only turn on explanations when explain is on, not when `infer` is on.