### PR TITLE
Toggling infer no longer toggles explanations

### DIFF
--- a/state/connection/TransactionState.kt
+++ b/state/connection/TransactionState.kt
@@ -98,7 +98,7 @@ class TransactionState constructor(
         else try {
             val options = typeDBOptions()
                 .infer(infer.value)
-                .explain(infer.value)
+                .explain(explain.value)
                 .transactionTimeoutMillis(ONE_HOUR_IN_MILLS)
             session.transaction(type, options)!!.apply {
                 onClose { close(TRANSACTION_CLOSED_ON_SERVER, it?.message ?: UNKNOWN) }

--- a/state/connection/TransactionState.kt
+++ b/state/connection/TransactionState.kt
@@ -43,7 +43,7 @@ class TransactionState constructor(
 ) {
 
     companion object {
-        const val ONE_HOUR_IN_MILLS = 60 * 60 * 1_000
+        const val ONE_HOUR_IN_MILLIS = 60 * 60 * 1_000
         private val LOGGER = KotlinLogging.logger {}
     }
 
@@ -98,7 +98,7 @@ class TransactionState constructor(
         else try {
             val options = typeDBOptions()
                 .infer(infer.value)
-                .explain(explain.value)
+                .explain(infer.value)
                 .transactionTimeoutMillis(ONE_HOUR_IN_MILLS)
             session.transaction(type, options)!!.apply {
                 onClose { close(TRANSACTION_CLOSED_ON_SERVER, it?.message ?: UNKNOWN) }

--- a/state/connection/TransactionState.kt
+++ b/state/connection/TransactionState.kt
@@ -98,8 +98,8 @@ class TransactionState constructor(
         else try {
             val options = typeDBOptions()
                 .infer(infer.value)
-                .explain(infer.value)
-                .transactionTimeoutMillis(ONE_HOUR_IN_MILLS)
+                .explain(explain.value)
+                .transactionTimeoutMillis(ONE_HOUR_IN_MILLIS)
             session.transaction(type, options)!!.apply {
                 onClose { close(TRANSACTION_CLOSED_ON_SERVER, it?.message ?: UNKNOWN) }
             }.also {

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -78,6 +78,26 @@ typedb_kt_test(
     server_windows_artifact = "@vaticle_typedb_artifact_windows//file",
 )
 
+typedb_kt_test(
+    name = "test-queryrunner",
+    srcs = ["QueryRunnerTest.kt"],
+    data = ["//test/integration/data:sample-github-data-files"],
+    test_class = "com.vaticle.typedb.studio.test.integration.QueryRunnerTest",
+    runtime_deps = skiko_runtime_platform,
+    deps = compose_test_libraries + [
+        "//framework/material",
+        "//state",
+        "//state/connection",
+        "//state/project",
+        "//state/page",
+        "//state/common",
+
+        "@vaticle_typedb_client_java//api",
+    ],
+    server_mac_artifact = "@vaticle_typedb_artifact_mac//file",
+    server_linux_artifact = "@vaticle_typedb_artifact_linux//file",
+    server_windows_artifact = "@vaticle_typedb_artifact_windows//file",
+)
 
 kt_jvm_test(
     name = "test-projectbrowser",

--- a/test/integration/QueryRunnerTest.kt
+++ b/test/integration/QueryRunnerTest.kt
@@ -44,7 +44,7 @@ import org.junit.Test
 class QueryRunnerTest: IntegrationTest() {
 
     @Test
-    fun InferNotExplainRegression() {
+    fun inferNotExplainRegression() {
         withTypeDB { typeDB ->
             runBlocking {
                 connectToTypeDB(composeRule, typeDB.address())

--- a/test/integration/QueryRunnerTest.kt
+++ b/test/integration/QueryRunnerTest.kt
@@ -66,7 +66,7 @@ class QueryRunnerTest: IntegrationTest() {
                 clickText(composeRule, Label.READ.lowercase())
                 clickText(composeRule, Label.INFER.lowercase())
 
-                clickIcon(composeRule, Icon.RUN, Delays.INSTANT)
+                StudioState.pages.active?.let { if (it.isRunnable) it.asRunnable().mayOpenAndRun() }
 
                 val priorTransaction = StudioState.client.session.transaction.transaction!!
                 val priorTransactionInfer = priorTransaction.options().infer().get()

--- a/test/integration/QueryRunnerTest.kt
+++ b/test/integration/QueryRunnerTest.kt
@@ -44,7 +44,7 @@ import org.junit.Test
 class QueryRunnerTest: IntegrationTest() {
 
     @Test
-    fun ExplainNotInferRegression() {
+    fun InferNotExplainRegression() {
         withTypeDB { typeDB ->
             runBlocking {
                 connectToTypeDB(composeRule, typeDB.address())

--- a/test/integration/QueryRunnerTest.kt
+++ b/test/integration/QueryRunnerTest.kt
@@ -26,13 +26,14 @@ import com.vaticle.typedb.client.api.TypeDBTransaction
 import com.vaticle.typedb.studio.framework.material.Icon
 import com.vaticle.typedb.studio.state.StudioState
 import com.vaticle.typedb.studio.state.common.util.Label
-import com.vaticle.typedb.studio.test.integration.common.StudioActions
+import com.vaticle.typedb.studio.test.integration.common.StudioActions.Delays
 import com.vaticle.typedb.studio.test.integration.common.StudioActions.clickIcon
 import com.vaticle.typedb.studio.test.integration.common.StudioActions.clickText
 import com.vaticle.typedb.studio.test.integration.data.Paths.SampleGitHubData
 import com.vaticle.typedb.studio.test.integration.common.StudioActions.connectToTypeDB
 import com.vaticle.typedb.studio.test.integration.common.StudioActions.copyFolder
 import com.vaticle.typedb.studio.test.integration.common.StudioActions.createDatabase
+import com.vaticle.typedb.studio.test.integration.common.StudioActions.delayAndRecompose
 import com.vaticle.typedb.studio.test.integration.common.StudioActions.openProject
 import com.vaticle.typedb.studio.test.integration.common.StudioActions.writeDataInteractively
 import com.vaticle.typedb.studio.test.integration.common.StudioActions.writeSchemaInteractively
@@ -55,7 +56,7 @@ class QueryRunnerTest: IntegrationTest() {
                 writeDataInteractively(composeRule, dbName = testID, SampleGitHubData.dataFile)
 
                 StudioState.client.session.tryOpen(database = testID, TypeDBSession.Type.DATA)
-                StudioActions.delayAndRecompose(composeRule, StudioActions.Delays.NETWORK_IO)
+                delayAndRecompose(composeRule, Delays.NETWORK_IO)
 
                 StudioState.project.current!!.directory.entries.find {
                     it.name == SampleGitHubData.collaboratorsQueryFile
@@ -65,10 +66,11 @@ class QueryRunnerTest: IntegrationTest() {
                 clickText(composeRule, Label.READ.lowercase())
                 clickText(composeRule, Label.INFER.lowercase())
 
-                clickIcon(composeRule, Icon.RUN, delayMillis = 0)
+                clickIcon(composeRule, Icon.RUN, Delays.INSTANT)
 
-                val priorTransactionInfer = StudioState.client.session.transaction.transaction!!.options().infer().get()
-                val priorTransactionExplain = StudioState.client.session.transaction.transaction!!.options().explain().get()
+                val priorTransaction = StudioState.client.session.transaction.transaction!!
+                val priorTransactionInfer = priorTransaction.options().infer().get()
+                val priorTransactionExplain = priorTransaction.options().explain().get()
 
                 assert(priorTransactionInfer && !priorTransactionExplain)
             }

--- a/test/integration/QueryRunnerTest.kt
+++ b/test/integration/QueryRunnerTest.kt
@@ -65,6 +65,7 @@ class QueryRunnerTest: IntegrationTest() {
 
                 clickText(composeRule, Label.DATA.lowercase())
                 clickText(composeRule, Label.READ.lowercase())
+                clickText(composeRule, Label.SNAPSHOT.lowercase())
                 clickText(composeRule, Label.INFER.lowercase())
 
                 StudioState.pages.active?.let { if (it.isRunnable) it.asRunnable().mayOpenAndRun() }
@@ -75,12 +76,12 @@ class QueryRunnerTest: IntegrationTest() {
                 val priorTransaction = StudioState.client.session.transaction.transaction!!
                 val priorTransactionType = priorTransaction.type()
                 val priorTransactionIsInfer = priorTransaction.options().infer().get()
-                val priorTransactionIsNotSnapshot = !StudioState.client.session.transaction.snapshot.value
+                val priorTransactionIsSnapshot = StudioState.client.session.transaction.snapshot.value
                 val priorTransactionIsNotExplain = !priorTransaction.options().explain().get()
 
                 assertEquals(priorTransactionType, TypeDBTransaction.Type.READ)
                 assert(priorTransactionIsInfer)
-                assert(priorTransactionIsNotSnapshot)
+                assert(priorTransactionIsSnapshot)
                 assert(priorTransactionIsNotExplain)
             }
         }

--- a/test/integration/QueryRunnerTest.kt
+++ b/test/integration/QueryRunnerTest.kt
@@ -73,16 +73,16 @@ class QueryRunnerTest: IntegrationTest() {
                 val sessionType = StudioState.client.session.type
                 assertEquals(sessionType, TypeDBSession.Type.DATA)
 
-                val priorTransaction = StudioState.client.session.transaction.transaction!!
-                val priorTransactionType = priorTransaction.type()
-                val priorTransactionIsInfer = priorTransaction.options().infer().get()
-                val priorTransactionIsSnapshot = StudioState.client.session.transaction.snapshot.value
-                val priorTransactionIsNotExplain = !priorTransaction.options().explain().get()
+                val transaction = StudioState.client.session.transaction.transaction!!
+                val transactionType = transaction.type()
+                val transactionIsInfer = transaction.options().infer().get()
+                val transactionIsSnapshot = StudioState.client.session.transaction.snapshot.value
+                val transactionIsNotExplain = !transaction.options().explain().get()
 
-                assertEquals(priorTransactionType, TypeDBTransaction.Type.READ)
-                assert(priorTransactionIsInfer)
-                assert(priorTransactionIsSnapshot)
-                assert(priorTransactionIsNotExplain)
+                assertEquals(transactionType, TypeDBTransaction.Type.READ)
+                assert(transactionIsInfer)
+                assert(transactionIsSnapshot)
+                assert(transactionIsNotExplain)
             }
         }
     }

--- a/test/integration/QueryRunnerTest.kt
+++ b/test/integration/QueryRunnerTest.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2022 Vaticle
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+// We need to access the private function StudioState.client.session.tryOpen, this allows us to.
+@file:Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
+
+package com.vaticle.typedb.studio.test.integration
+
+
+import com.vaticle.typedb.client.api.TypeDBSession
+import com.vaticle.typedb.client.api.TypeDBTransaction
+import com.vaticle.typedb.studio.framework.material.Icon
+import com.vaticle.typedb.studio.state.StudioState
+import com.vaticle.typedb.studio.state.common.util.Label
+import com.vaticle.typedb.studio.test.integration.common.StudioActions
+import com.vaticle.typedb.studio.test.integration.common.StudioActions.clickIcon
+import com.vaticle.typedb.studio.test.integration.common.StudioActions.clickText
+import com.vaticle.typedb.studio.test.integration.data.Paths.SampleGitHubData
+import com.vaticle.typedb.studio.test.integration.common.StudioActions.connectToTypeDB
+import com.vaticle.typedb.studio.test.integration.common.StudioActions.copyFolder
+import com.vaticle.typedb.studio.test.integration.common.StudioActions.createDatabase
+import com.vaticle.typedb.studio.test.integration.common.StudioActions.openProject
+import com.vaticle.typedb.studio.test.integration.common.StudioActions.writeDataInteractively
+import com.vaticle.typedb.studio.test.integration.common.StudioActions.writeSchemaInteractively
+import com.vaticle.typedb.studio.test.integration.common.TypeDBRunners.withTypeDB
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+
+class QueryRunnerTest: IntegrationTest() {
+
+    @Test
+    fun ExplainNotInferRegression() {
+        withTypeDB { typeDB ->
+            runBlocking {
+                connectToTypeDB(composeRule, typeDB.address())
+                createDatabase(composeRule, dbName = testID)
+                copyFolder(source = SampleGitHubData.path, destination = testID)
+                openProject(composeRule, projectDirectory = testID)
+                writeSchemaInteractively(composeRule, dbName = testID, SampleGitHubData.schemaFile)
+                writeDataInteractively(composeRule, dbName = testID, SampleGitHubData.dataFile)
+
+                StudioState.client.session.tryOpen(database = testID, TypeDBSession.Type.DATA)
+                StudioActions.delayAndRecompose(composeRule, StudioActions.Delays.NETWORK_IO)
+
+                StudioState.project.current!!.directory.entries.find {
+                    it.name == SampleGitHubData.collaboratorsQueryFile
+                }!!.asFile().tryOpen()
+
+                clickText(composeRule, Label.DATA.lowercase())
+                clickText(composeRule, Label.READ.lowercase())
+                clickText(composeRule, Label.INFER.lowercase())
+
+                clickIcon(composeRule, Icon.RUN, delayMillis = 0)
+
+                val priorTransactionInfer = StudioState.client.session.transaction.transaction!!.options().infer().get()
+                val priorTransactionExplain = StudioState.client.session.transaction.transaction!!.options().explain().get()
+
+                assert(priorTransactionInfer && !priorTransactionExplain)
+            }
+        }
+    }
+}

--- a/test/integration/QueryRunnerTest.kt
+++ b/test/integration/QueryRunnerTest.kt
@@ -45,7 +45,7 @@ import org.junit.Test
 class QueryRunnerTest: IntegrationTest() {
 
     @Test
-    fun inferNotExplainRegression() {
+    fun toolbarTogglesAreReflected() {
         withTypeDB { typeDB ->
             runBlocking {
                 connectToTypeDB(composeRule, typeDB.address())
@@ -68,11 +68,20 @@ class QueryRunnerTest: IntegrationTest() {
 
                 StudioState.pages.active?.let { if (it.isRunnable) it.asRunnable().mayOpenAndRun() }
 
+                val sessionIsData = StudioState.client.session.isData
+                val transactionIsRead = StudioState.client.session.transaction.transaction!!.type().isRead
+                val snapshotIsDisabled = !StudioState.client.session.transaction.snapshot.value
+
+                assert(sessionIsData)
+                assert(transactionIsRead)
+                assert(snapshotIsDisabled)
+
                 val priorTransaction = StudioState.client.session.transaction.transaction!!
                 val priorTransactionInfer = priorTransaction.options().infer().get()
                 val priorTransactionExplain = priorTransaction.options().explain().get()
 
-                assert(priorTransactionInfer && !priorTransactionExplain)
+                assert(priorTransactionInfer)
+                assert(!priorTransactionExplain)
             }
         }
     }

--- a/test/integration/QuickstartTest.kt
+++ b/test/integration/QuickstartTest.kt
@@ -33,7 +33,7 @@ import org.junit.Test
 class QuickstartTest: IntegrationTest() {
 
     @Test
-    fun Quickstart() {
+    fun quickstart() {
         withTypeDB { typeDB ->
             runBlocking {
                 connectToTypeDB(composeRule, typeDB.address())

--- a/test/integration/common/StudioActions.kt
+++ b/test/integration/common/StudioActions.kt
@@ -58,9 +58,7 @@ object StudioActions {
 
     suspend fun clickText(composeRule: ComposeContentTestRule, text: String, delayMillis: Int = Delays.RECOMPOSE) {
         composeRule.onNodeWithText(text).performClick()
-        if (delayMillis > Delays.INSTANT) {
-            delayAndRecompose(composeRule, delayMillis)
-        }
+        delayAndRecompose(composeRule, delayMillis)
     }
 
     fun clickAllInstancesOfText(composeRule: ComposeContentTestRule, text: String) {
@@ -246,7 +244,6 @@ object StudioActions {
     }
 
     object Delays {
-        const val INSTANT = 0
         const val RECOMPOSE = 500
         const val FILE_IO = 750
         const val NETWORK_IO = 1_500

--- a/test/integration/common/StudioActions.kt
+++ b/test/integration/common/StudioActions.kt
@@ -21,6 +21,7 @@
 
 package com.vaticle.typedb.studio.test.integration.common
 
+import androidx.compose.ui.test.ComposeTimeoutException
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.assertAll
 import androidx.compose.ui.test.hasClickAction
@@ -58,7 +59,7 @@ object StudioActions {
 
     suspend fun clickText(composeRule: ComposeContentTestRule, text: String, delayMillis: Int = Delays.RECOMPOSE) {
         composeRule.onNodeWithText(text).performClick()
-        delayAndRecompose(composeRule, delayMillis)
+        if (delayMillis > 0) delayAndRecompose(composeRule, delayMillis)
     }
 
     fun clickAllInstancesOfText(composeRule: ComposeContentTestRule, text: String) {
@@ -81,12 +82,12 @@ object StudioActions {
     }
 
     fun copyFolder(source: String, destination: String): Path {
-        val destination = File(File(destination).absolutePath)
+        val absoluteDestination = File(File(destination).absolutePath)
 
-        destination.deleteRecursively()
-        File(source).copyRecursively(overwrite = true, target = destination)
+        absoluteDestination.deleteRecursively()
+        File(source).copyRecursively(overwrite = true, target = absoluteDestination)
 
-        return destination.toPath()
+        return absoluteDestination.toPath()
     }
 
     /// Wait `timeMillis` milliseconds, then wait for all recompositions to finish.
@@ -176,7 +177,6 @@ object StudioActions {
         StudioState.project.current!!.directory.entries.find { it.name == schemaFileName }!!.asFile().tryOpen()
 
         clickIcon(composeRule, Icon.RUN, delayMillis = Delays.NETWORK_IO)
-
         clickIcon(composeRule, Icon.COMMIT, delayMillis = Delays.NETWORK_IO)
 
         waitForConditionAndRecompose(composeRule, Errors.SCHEMA_WRITE_FAILED) {
@@ -197,7 +197,6 @@ object StudioActions {
         StudioState.project.current!!.directory.entries.find { it.name == dataFileName }!!.asFile().tryOpen()
 
         clickIcon(composeRule, Icon.RUN, delayMillis = Delays.NETWORK_IO)
-
         clickIcon(composeRule, Icon.COMMIT, delayMillis = Delays.NETWORK_IO)
 
         waitForConditionAndRecompose(composeRule, Errors.DATA_WRITE_FAILED) {

--- a/test/integration/common/StudioActions.kt
+++ b/test/integration/common/StudioActions.kt
@@ -21,7 +21,6 @@
 
 package com.vaticle.typedb.studio.test.integration.common
 
-import androidx.compose.ui.test.ComposeTimeoutException
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.assertAll
 import androidx.compose.ui.test.hasClickAction
@@ -177,6 +176,7 @@ object StudioActions {
         StudioState.project.current!!.directory.entries.find { it.name == schemaFileName }!!.asFile().tryOpen()
 
         clickIcon(composeRule, Icon.RUN, delayMillis = Delays.NETWORK_IO)
+
         clickIcon(composeRule, Icon.COMMIT, delayMillis = Delays.NETWORK_IO)
 
         waitForConditionAndRecompose(composeRule, Errors.SCHEMA_WRITE_FAILED) {
@@ -197,6 +197,7 @@ object StudioActions {
         StudioState.project.current!!.directory.entries.find { it.name == dataFileName }!!.asFile().tryOpen()
 
         clickIcon(composeRule, Icon.RUN, delayMillis = Delays.NETWORK_IO)
+
         clickIcon(composeRule, Icon.COMMIT, delayMillis = Delays.NETWORK_IO)
 
         waitForConditionAndRecompose(composeRule, Errors.DATA_WRITE_FAILED) {

--- a/test/integration/common/StudioActions.kt
+++ b/test/integration/common/StudioActions.kt
@@ -58,7 +58,9 @@ object StudioActions {
 
     suspend fun clickText(composeRule: ComposeContentTestRule, text: String, delayMillis: Int = Delays.RECOMPOSE) {
         composeRule.onNodeWithText(text).performClick()
-        if (delayMillis > 0) delayAndRecompose(composeRule, delayMillis)
+        if (delayMillis > Delays.INSTANT) {
+            delayAndRecompose(composeRule, delayMillis)
+        }
     }
 
     fun clickAllInstancesOfText(composeRule: ComposeContentTestRule, text: String) {
@@ -244,6 +246,7 @@ object StudioActions {
     }
 
     object Delays {
+        const val INSTANT = 0
         const val RECOMPOSE = 500
         const val FILE_IO = 750
         const val NETWORK_IO = 1_500


### PR DESCRIPTION
## What is the goal of this PR?

When we run a query, we automatically include `TypeDBOptions` given the state of the toolbar. Currently, we derive the value of `explain` for `TypeDBOptions` from `infer`. We should derive it from `explain`.

## What are the changes implemented in this PR?

We only turn on explanations when explain is on, not when `infer` is on.

We have also added a regression test to ensure that this issue does not return.