### PR TITLE
Fix replace shortcut for text editor

### DIFF
--- a/framework/common/KeyMapper.kt
+++ b/framework/common/KeyMapper.kt
@@ -305,6 +305,7 @@ interface KeyMapper {
                     Keys.DirectionDown -> Command.MOVE_END
                     Keys.Backspace -> Command.DELETE_LINE_START
                     Keys.Q -> Command.QUIT
+                    Keys.R -> Command.REPLACE
                     else -> null
                 }
                 // Emacs-like shortcuts
@@ -338,7 +339,6 @@ interface KeyMapper {
                     Keys.D -> Command.DELETE_CHAR_NEXT
                     Keys.K -> Command.DELETE_LINE_END
                     Keys.O -> Command.ENTER
-                    Keys.R -> Command.REPLACE
                     else -> null
                 }
                 event.isAltPressed && event.isShiftPressed -> when (event.key) {


### PR DESCRIPTION
## What is the goal of this PR?

The shortcut to open the replace dialog in Studio **on macOS** was `CTRL+R`, but it should be `CMD+R`. This has now been fixed.

## What are the changes implemented in this PR?

This is a very small change 1+ 1- change, moving the line from under the CTRL modifier case to the CMD modifier case. Users should now be able to run `CMD+R` to open the replace functionality in Studio.