### PR TITLE
Home/end keys move to beginning/end of content

### DIFF
--- a/framework/common/KeyMapper.kt
+++ b/framework/common/KeyMapper.kt
@@ -238,8 +238,8 @@ interface KeyMapper {
                     Keys.DirectionDown -> Command.MOVE_LINE_DOWN
                     Keys.PageUp -> Command.MOVE_PAGE_UP
                     Keys.PageDown -> Command.MOVE_PAGE_DOWN
-                    Keys.MoveHome -> Command.MOVE_LINE_START
-                    Keys.MoveEnd -> Command.MOVE_LINE_END
+                    Keys.MoveHome -> Command.MOVE_HOME
+                    Keys.MoveEnd -> Command.MOVE_END
                     Keys.Enter, Keys.EnterNumPad -> Command.ENTER
                     Keys.Backspace -> Command.DELETE_CHAR_PREV
                     Keys.Delete -> Command.DELETE_CHAR_NEXT


### PR DESCRIPTION
## What is the goal of this PR?

We've changed the behaviour of the home key in the text editor, moving it to the beginning of the content covered by the text editor rather than the beginning of the line. This falls in line with our current implementation where SHIFT+HOME selects everything to the beginning of the content.

## What are the changes implemented in this PR?

We've changed 
* `Keys.MoveHome` to map to `Command.MOVE_HOME` and
* `Keys.MoveEnd` to map to `Command.MOVE_END`.