### PR TITLE
Transaction Timeout Preference

### DIFF
--- a/module/preference/PreferenceDialog.kt
+++ b/module/preference/PreferenceDialog.kt
@@ -441,13 +441,8 @@ object PreferenceDialog {
                 invalidWarning = Label.PREFERENCE_TRANSACTION_TIMEOUT_MINS_INPUT_WARNING,
                 caption = PREFERENCES_TRANSACTION_TIMEOUT_CAPTION
             ) {/* validator = */
-                val transactionTimeoutMins = it.toLongOrNull()
-
-                if (transactionTimeoutMins != null) {
-                    transactionTimeoutMins in 0..10000
-                } else {
-                    false
-                }
+                val transactionTimeoutMins = it.toLongOrNull() ?: return@TextInputValidated false
+                transactionTimeoutMins in 0..10000
             }
 
             override val preferences: List<PreferenceField> = listOf(matchQueryLimit, transactionTimeoutMins)

--- a/module/preference/PreferenceDialog.kt
+++ b/module/preference/PreferenceDialog.kt
@@ -442,7 +442,7 @@ object PreferenceDialog {
                 caption = PREFERENCES_TRANSACTION_TIMEOUT_CAPTION
             ) {/* validator = */
                 val transactionTimeoutMins = it.toLongOrNull() ?: return@TextInputValidated false
-                transactionTimeoutMins in 0..10000
+                transactionTimeoutMins in 1..10000
             }
 
             override val preferences: List<PreferenceField> = listOf(matchQueryLimit, transactionTimeoutMins)

--- a/module/preference/PreferenceDialog.kt
+++ b/module/preference/PreferenceDialog.kt
@@ -441,10 +441,8 @@ object PreferenceDialog {
                 invalidWarning = Label.PREFERENCE_TRANSACTION_TIMEOUT_MINS_INPUT_WARNING,
                 caption = PREFERENCES_TRANSACTION_TIMEOUT_CAPTION
             ) {/* validator = */
-                val transactionTimeoutMinsOrNull = it.toLongOrNull()
-                transactionTimeoutMinsOrNull != null
-                        && transactionTimeoutMinsOrNull >= 0
-                        && transactionTimeoutMinsOrNull <= 10000
+                val transactionTimeoutMins = it.toLongOrNull() ?: false
+                transactionTimeoutMins in 0..10000
             }
 
             override val preferences: List<PreferenceField> = listOf(matchQueryLimit, transactionTimeoutMins)

--- a/module/preference/PreferenceDialog.kt
+++ b/module/preference/PreferenceDialog.kt
@@ -441,8 +441,10 @@ object PreferenceDialog {
                 invalidWarning = Label.PREFERENCE_TRANSACTION_TIMEOUT_MINS_INPUT_WARNING,
                 caption = PREFERENCES_TRANSACTION_TIMEOUT_CAPTION
             ) {/* validator = */
-                val longOrNull = it.toLongOrNull()
-                longOrNull != null && longOrNull >= 0 && longOrNull <= 10000
+                val transactionTimeoutMinsOrNull = it.toLongOrNull()
+                transactionTimeoutMinsOrNull != null
+                        && transactionTimeoutMinsOrNull >= 0
+                        && transactionTimeoutMinsOrNull <= 10000
             }
 
             override val preferences: List<PreferenceField> = listOf(matchQueryLimit, transactionTimeoutMins)

--- a/module/preference/PreferenceDialog.kt
+++ b/module/preference/PreferenceDialog.kt
@@ -51,7 +51,9 @@ import com.vaticle.typedb.common.collection.Either
 import com.vaticle.typedb.studio.framework.common.theme.Theme
 import com.vaticle.typedb.studio.framework.material.Dialog
 import com.vaticle.typedb.studio.framework.material.Form
+import com.vaticle.typedb.studio.framework.material.Form.ColumnSpacer
 import com.vaticle.typedb.studio.framework.material.Form.Field
+import com.vaticle.typedb.studio.framework.material.Form.RowSpacer
 import com.vaticle.typedb.studio.framework.material.Form.State
 import com.vaticle.typedb.studio.framework.material.Form.Text
 import com.vaticle.typedb.studio.framework.material.Form.TextButton
@@ -74,9 +76,11 @@ import com.vaticle.typedb.studio.service.common.util.Label.QUERY_RUNNER
 import com.vaticle.typedb.studio.service.common.util.Label.RESET
 import com.vaticle.typedb.studio.service.common.util.Label.SET_QUERY_LIMIT
 import com.vaticle.typedb.studio.service.common.util.Label.TEXT_EDITOR
-import com.vaticle.typedb.studio.service.common.util.Sentence.IGNORED_PATHS_CAPTION
+import com.vaticle.typedb.studio.service.common.util.Label.TRANSACTION_TIMEOUT_MINS
 import com.vaticle.typedb.studio.service.common.util.Sentence.PREFERENCES_GRAPH_OUTPUT_CAPTION
+import com.vaticle.typedb.studio.service.common.util.Sentence.PREFERENCES_IGNORED_PATHS_CAPTION
 import com.vaticle.typedb.studio.service.common.util.Sentence.PREFERENCES_MATCH_QUERY_LIMIT_CAPTION
+import com.vaticle.typedb.studio.service.common.util.Sentence.PREFERENCES_TRANSACTION_TIMEOUT_CAPTION
 import com.vaticle.typedb.studio.service.page.Navigable
 
 object PreferenceDialog {
@@ -350,7 +354,7 @@ object PreferenceDialog {
                 }
             }
             SpacedHorizontalSeparator()
-            preferences.forEach { it.Display() }
+            preferences.forEach { it.Display(); ColumnSpacer() }
         }
 
         class Root(override val entries: List<PreferenceGroup> = emptyList()) : PreferenceGroup(entries = entries) {
@@ -403,7 +407,7 @@ object PreferenceDialog {
             private var ignoredPaths = PreferenceField.MultilineTextInput(
                 initValue = ignoredPathsString,
                 label = PROJECT_IGNORED_PATHS,
-                caption = IGNORED_PATHS_CAPTION,
+                caption = PREFERENCES_IGNORED_PATHS_CAPTION,
             )
 
             override val preferences: List<PreferenceField> = listOf(ignoredPaths)
@@ -422,6 +426,7 @@ object PreferenceDialog {
         class QueryRunner : PreferenceGroup(QUERY_RUNNER) {
             companion object {
                 private const val QUERY_LIMIT_PLACEHOLDER = "1000"
+                private const val TRANSACTION_TIMEOUT_MINS_PLACEHOLDER = "5"
             }
 
             private var matchQueryLimit = PreferenceField.TextInputValidated(
@@ -430,16 +435,30 @@ object PreferenceDialog {
                 invalidWarning = Label.PREFERENCE_INTEGER_WARNING, caption = PREFERENCES_MATCH_QUERY_LIMIT_CAPTION
             ) {/* validator = */ it.toLongOrNull() != null && it.toLongOrNull()!! >= 0 }
 
-            override val preferences: List<PreferenceField> = listOf(matchQueryLimit)
+            private var transactionTimeoutMins = PreferenceField.TextInputValidated(
+                initValue = preferenceSrv.transactionTimeoutMins.toString(),
+                label = TRANSACTION_TIMEOUT_MINS, placeholder = TRANSACTION_TIMEOUT_MINS_PLACEHOLDER,
+                invalidWarning = Label.PREFERENCE_TRANSACTION_TIMEOUT_MINS_INPUT_WARNING,
+                caption = PREFERENCES_TRANSACTION_TIMEOUT_CAPTION
+            ) {/* validator = */
+                val longOrNull = it.toLongOrNull()
+                longOrNull != null && longOrNull >= 0 && longOrNull <= 10000
+            }
+
+            override val preferences: List<PreferenceField> = listOf(matchQueryLimit, transactionTimeoutMins)
 
             override fun submit() {
                 preferenceSrv.matchQueryLimit = matchQueryLimit.value.toLong()
+                preferenceSrv.transactionTimeoutMins = transactionTimeoutMins.value.toLong()
                 matchQueryLimit.modified = false
+                transactionTimeoutMins.modified = false
             }
 
             override fun reset() {
                 matchQueryLimit.value = preferenceSrv.matchQueryLimit.toString()
+                transactionTimeoutMins.value = preferenceSrv.transactionTimeoutMins.toString()
                 matchQueryLimit.modified = false
+                transactionTimeoutMins.modified = false
             }
         }
     }
@@ -522,11 +541,11 @@ object PreferenceDialog {
         TextButton(CANCEL) {
             state.cancel()
         }
-        Form.RowSpacer()
+        RowSpacer()
         TextButton(APPLY, enabled = state.isModified() && state.isValid()) {
             state.apply()
         }
-        Form.RowSpacer()
+        RowSpacer()
         TextButton(OK) {
             state.ok()
         }
@@ -543,8 +562,8 @@ object PreferenceDialog {
 
     @Composable
     private fun SpacedHorizontalSeparator() {
-        Form.ColumnSpacer()
+        ColumnSpacer()
         Separator.Horizontal()
-        Form.ColumnSpacer()
+        ColumnSpacer()
     }
 }

--- a/module/preference/PreferenceDialog.kt
+++ b/module/preference/PreferenceDialog.kt
@@ -441,8 +441,13 @@ object PreferenceDialog {
                 invalidWarning = Label.PREFERENCE_TRANSACTION_TIMEOUT_MINS_INPUT_WARNING,
                 caption = PREFERENCES_TRANSACTION_TIMEOUT_CAPTION
             ) {/* validator = */
-                val transactionTimeoutMins = it.toLongOrNull() ?: false
-                transactionTimeoutMins in 0..10000
+                val transactionTimeoutMins = it.toLongOrNull()
+
+                if (transactionTimeoutMins != null) {
+                    transactionTimeoutMins in 0..10000
+                } else {
+                    false
+                }
             }
 
             override val preferences: List<PreferenceField> = listOf(matchQueryLimit, transactionTimeoutMins)

--- a/service/common/DataService.kt
+++ b/service/common/DataService.kt
@@ -113,17 +113,17 @@ class DataService {
             get() = properties?.getProperty(IGNORED_PATHS)?.split(',')?.map { it.trim() }
             set(value) = setProperty(IGNORED_PATHS, value!!.joinToString(","))
 
-        var matchQueryLimit: String?
-            get() = properties?.getProperty(MATCH_QUERY_LIMIT)
-            set(value) = setProperty(MATCH_QUERY_LIMIT, value!!)
+        var matchQueryLimit: Long?
+            get() = properties?.getProperty(MATCH_QUERY_LIMIT)?.toLong()
+            set(value) = setProperty(MATCH_QUERY_LIMIT, value!!.toString())
+
+        var transactionTimeoutMins: Long?
+            get() = properties?.getProperty(TRANSACTION_TIMEOUT_MINS)?.toLong()
+            set(value) = setProperty(TRANSACTION_TIMEOUT_MINS, value!!.toString())
 
         var graphOutputEnabled: Boolean?
             get() = properties?.getProperty(GRAPH_OUTPUT)?.toBoolean()
             set(value) = setProperty(GRAPH_OUTPUT, value.toString())
-
-        var transactionTimeoutMins: String?
-            get() = properties?.getProperty(TRANSACTION_TIMEOUT_MINS)
-            set(value) = setProperty(TRANSACTION_TIMEOUT_MINS, value!!)
     }
 
     var properties: Properties? by mutableStateOf(null)

--- a/service/common/DataService.kt
+++ b/service/common/DataService.kt
@@ -99,9 +99,10 @@ class DataService {
     }
 
     inner class Preferences {
-        private val AUTO_SAVE = "editor.autosave"
-        private val IGNORED_PATHS = "project.ignoredpaths"
-        private val MATCH_QUERY_LIMIT = "query.matchlimit"
+        private val AUTO_SAVE = "editor.auto-save"
+        private val IGNORED_PATHS = "project.ignored-paths"
+        private val MATCH_QUERY_LIMIT = "query.match-limit"
+        private val TRANSACTION_TIMEOUT_MINS = "query.transaction-timeout-mins"
         private val GRAPH_OUTPUT = "graph.output"
 
         var autoSave: Boolean?
@@ -119,6 +120,10 @@ class DataService {
         var graphOutputEnabled: Boolean?
             get() = properties?.getProperty(GRAPH_OUTPUT)?.toBoolean()
             set(value) = setProperty(GRAPH_OUTPUT, value.toString())
+
+        var transactionTimeoutMins: String?
+            get() = properties?.getProperty(TRANSACTION_TIMEOUT_MINS)
+            set(value) = setProperty(TRANSACTION_TIMEOUT_MINS, value!!)
     }
 
     var properties: Properties? by mutableStateOf(null)

--- a/service/common/PreferenceService.kt
+++ b/service/common/PreferenceService.kt
@@ -36,12 +36,12 @@ class PreferenceService(dataSrv: DataService) {
         set(value) = run { preferences.graphOutputEnabled = value }
 
     var matchQueryLimit: Long = Defaults.matchQueryLimit
-        get() = preferences.matchQueryLimit?.toLong() ?: field
-        set(value) = run { preferences.matchQueryLimit = value.toString() }
+        get() = preferences.matchQueryLimit ?: field
+        set(value) = run { preferences.matchQueryLimit = value }
 
     var transactionTimeoutMins: Long = Defaults.transactionTimeoutMins
-        get() = preferences.transactionTimeoutMins?.toLong() ?: field
-        set(value) = run { preferences.transactionTimeoutMins = value.toString() }
+        get() = preferences.transactionTimeoutMins ?: field
+        set(value) = run { preferences.transactionTimeoutMins = value }
 
     var ignoredPaths: List<String> = Defaults.ignoredPaths
         get() = preferences.ignoredPaths ?: field

--- a/service/common/PreferenceService.kt
+++ b/service/common/PreferenceService.kt
@@ -39,6 +39,10 @@ class PreferenceService(dataSrv: DataService) {
         get() = preferences.matchQueryLimit?.toLong() ?: field
         set(value) = run { preferences.matchQueryLimit = value.toString() }
 
+    var transactionTimeoutMins: Long = Defaults.transactionTimeoutMins
+        get() = preferences.transactionTimeoutMins?.toLong() ?: field
+        set(value) = run { preferences.transactionTimeoutMins = value.toString() }
+
     var ignoredPaths: List<String> = Defaults.ignoredPaths
         get() = preferences.ignoredPaths ?: field
         set(value) = run { preferences.ignoredPaths = value }
@@ -58,5 +62,6 @@ class PreferenceService(dataSrv: DataService) {
         val graphOutputEnabled = true
         val matchQueryLimit = 1000L
         val ignoredPaths = listOf(".git")
+        val transactionTimeoutMins = 5L
     }
 }

--- a/service/common/util/Label.kt
+++ b/service/common/util/Label.kt
@@ -158,7 +158,7 @@ object Label {
     const val POPULATE_REQUIRED_FIELDS = "Populate Required Fields"
     const val PREFERENCE_INTEGER_WARNING = "Please enter a positive integer."
     const val PREFERENCE_TRANSACTION_TIMEOUT_MINS_INPUT_WARNING =
-        "Please enter an integer between 0 and 10000."
+        "Please enter an integer between 1 and 10000."
     const val PREVIEW = "Preview"
     const val PREVIOUS_OCCURRENCE = "Previous Occurrence"
     const val PROJECT = "Project"

--- a/service/common/util/Label.kt
+++ b/service/common/util/Label.kt
@@ -157,6 +157,8 @@ object Label {
     const val PLAYS = "Plays"
     const val POPULATE_REQUIRED_FIELDS = "Populate Required Fields"
     const val PREFERENCE_INTEGER_WARNING = "Please input a positive integer."
+    const val PREFERENCE_TRANSACTION_TIMEOUT_MINS_INPUT_WARNING =
+        "Please input a positive integer less than or equal to 10000."
     const val PREVIEW = "Preview"
     const val PREVIOUS_OCCURRENCE = "Previous Occurrence"
     const val PROJECT = "Project"
@@ -232,6 +234,7 @@ object Label {
     const val TITLE = "Title"
     const val TRACE = "Trace"
     const val TRANSACTION_STATUS = "Transaction Status"
+    const val TRANSACTION_TIMEOUT_MINS = "Transaction Timeout (mins)"
     const val TRANSACTION_TYPE = "Transaction Type"
     const val TYPE = "Type"
     const val TYPEDB_STUDIO = "TypeDB Studio"

--- a/service/common/util/Label.kt
+++ b/service/common/util/Label.kt
@@ -158,7 +158,7 @@ object Label {
     const val POPULATE_REQUIRED_FIELDS = "Populate Required Fields"
     const val PREFERENCE_INTEGER_WARNING = "Please input a positive integer."
     const val PREFERENCE_TRANSACTION_TIMEOUT_MINS_INPUT_WARNING =
-        "Please input a positive integer less than or equal to 10000."
+        "Please enter an integer between 0 and 10000."
     const val PREVIEW = "Preview"
     const val PREVIOUS_OCCURRENCE = "Previous Occurrence"
     const val PROJECT = "Project"

--- a/service/common/util/Label.kt
+++ b/service/common/util/Label.kt
@@ -156,7 +156,7 @@ object Label {
     const val PATH_TO_CA_CERTIFICATE = "/path/to/ca/certificate"
     const val PLAYS = "Plays"
     const val POPULATE_REQUIRED_FIELDS = "Populate Required Fields"
-    const val PREFERENCE_INTEGER_WARNING = "Please input a positive integer."
+    const val PREFERENCE_INTEGER_WARNING = "Please enter a positive integer."
     const val PREFERENCE_TRANSACTION_TIMEOUT_MINS_INPUT_WARNING =
         "Please enter an integer between 0 and 10000."
     const val PREVIEW = "Preview"

--- a/service/common/util/Sentence.kt
+++ b/service/common/util/Sentence.kt
@@ -106,8 +106,6 @@ object Sentence {
                 "Enabling snapshot in a 'read' transaction allows you to query for explanations of inferred concept answers. " +
                 "The transaction will be opened on the latest snapshot when the first query is ran. " +
                 BUTTON_ENABLED_WHEN_SESSION_OPEN
-    const val PREFERENCES_GRAPH_OUTPUT_CAPTION =
-        "When running a match query, display a graph output."
     const val INTERACTIVE_MODE_DESCRIPTION =
         "Running TypeDB Studio in 'interactive' mode (as opposed to 'script' mode), means that you can interact with a " +
                 "TypeDB server interactively. In 'script' mode, you have to declare the user, database, session, and " +
@@ -124,9 +122,13 @@ object Sentence {
         "Below is the list of databases on your TypeDB Server. You can delete them individually, or create new ones. "
     const val OUTPUT_RESPONSE_TIME_DESCRIPTION =
         "Duration to collect all answers of the query from the server."
+    const val PREFERENCES_GRAPH_OUTPUT_CAPTION =
+        "When running a match query, display a graph output."
+    const val PREFERENCES_IGNORED_PATHS_CAPTION = "Ignore files matching glob expressions. Separate entries by line."
     const val PREFERENCES_MATCH_QUERY_LIMIT_CAPTION =
         "When running a match query, limit the number of results to this value."
-    const val IGNORED_PATHS_CAPTION = "Ignore files matching glob expressions. Separate entries by line."
+    const val PREFERENCES_TRANSACTION_TIMEOUT_CAPTION =
+        "Set the timeout of transactions (in minutes) to this value."
     const val QUERY_RESPONSE_TIME_DESCRIPTION =
         "Duration to collect auxiliary information/concepts to display informative log & graph output."
     const val RENAME_DIRECTORY =

--- a/service/connection/QueryRunner.kt
+++ b/service/connection/QueryRunner.kt
@@ -200,7 +200,7 @@ class QueryRunner constructor(
         noResultMsg = INSERT_QUERY_NO_RESULT,
         queryStr = query.toString(),
         stream = Response.Stream.ConceptMaps(INSERT)
-    ) { transaction.query().insert(query, transactionState.typeDBOptions().prefetch(true)) }
+    ) { transaction.query().insert(query, transactionState.defaultTypeDBOptions().prefetch(true)) }
 
     private fun runUpdateQuery(query: TypeQLUpdate) = runStreamingQuery(
         name = UPDATE_QUERY,
@@ -208,7 +208,7 @@ class QueryRunner constructor(
         noResultMsg = UPDATE_QUERY_NO_RESULT,
         queryStr = query.toString(),
         stream = Response.Stream.ConceptMaps(UPDATE)
-    ) { transaction.query().update(query, transactionState.typeDBOptions().prefetch(true)) }
+    ) { transaction.query().update(query, transactionState.defaultTypeDBOptions().prefetch(true)) }
 
     private fun runMatchQuery(query: TypeQLMatch) = runStreamingQuery(
         name = MATCH_QUERY,

--- a/service/connection/TransactionState.kt
+++ b/service/connection/TransactionState.kt
@@ -174,10 +174,6 @@ class TransactionState constructor(
     }
 
     internal fun defaultTypeDBOptions(): TypeDBOptions {
-        return if (session.client.isCluster) {
-            TypeDBOptions.core()
-        } else {
-            TypeDBOptions.cluster()
-        }
+        return if (session.client.isCluster) TypeDBOptions.cluster() else TypeDBOptions.core()
     }
 }


### PR DESCRIPTION
## What is the goal of this PR?

We've added a field to the query runner preferences, allowing for the configuration of transaction timeouts.

Closes https://github.com/vaticle/typedb-studio/issues/642.

## What are the changes implemented in this PR?

We've introduced:
* a preference field named `transactionTimeoutMins`, allowing the user to input a number of minutes between 1 and 10000 inclusive.
* the associated labels, captions, placeholders and additional assets to support the user in understanding the function of the preference field.

Additionally, we've refactored 
* `DataService` to provide the appropriate type rather than splitting half the conversions from strings to the appropriate between `PreferenceService` and `DataService`.
* ColumnSpacer, RowSpacer and other composables inherited from Form to not use redundant qualifiers. We used to have our own column and row spacers, but this was refactored out.