### PR TITLE
Allow running selected query from non-TypeQL files.

### DIFF
--- a/framework/editor/EventHandler.kt
+++ b/framework/editor/EventHandler.kt
@@ -316,7 +316,7 @@ internal class EventHandler constructor(
         icon = Icon.RUN,
         iconColor = { Theme.studio.secondary },
         info = "${KeyMapper.CURRENT.modKey} + ${Label.ENTER}",
-        enabled = processor.file?.isRunnable == true && target.selection != null && Service.client.isReadyToRunQuery
+        enabled = target.selection != null && Service.client.isReadyToRunQuery
     ) { mayRunSelection() }
 
     private fun increaseTextSizeMenuItem() = ContextMenu.Item(

--- a/framework/editor/EventHandler.kt
+++ b/framework/editor/EventHandler.kt
@@ -229,7 +229,7 @@ internal class EventHandler constructor(
 
     private fun mayRunSelection() {
         if (!Service.client.isReadyToRunQuery) return
-        processor.file?.mayOpenAndRun(target.selectedText().text)
+        processor.file?.mayRunSnippet(target.selectedText().text)
     }
 
     private fun hideToolbar(): Boolean {

--- a/service/page/Pageable.kt
+++ b/service/page/Pageable.kt
@@ -61,7 +61,7 @@ interface Pageable {
         val isRunning: Boolean get() = runners.isRunning
         override val isRunnable: Boolean get() = true
 
-        fun mayOpenAndRun(content: String = runContent)
+        fun mayOpenAndRun()
 
         override fun asRunnable(): Runnable {
             return this

--- a/service/project/FileState.kt
+++ b/service/project/FileState.kt
@@ -188,7 +188,7 @@ class FileState internal constructor(
     }
 
     override fun mayOpenAndRun(content: String) {
-        if (!isRunnable || (!isOpen && !tryOpen())) return
+        if (!isOpen && !tryOpen()) return
         projectSrv.client.run(content)?.let { runners.launched(it) }
     }
 

--- a/service/project/FileState.kt
+++ b/service/project/FileState.kt
@@ -193,7 +193,6 @@ class FileState internal constructor(
     }
 
     fun mayRunSnippet(snippet: String) {
-        if (!isOpen && !tryOpen()) return
         projectSrv.client.run(snippet)?.let { runners.launched(it) }
     }
 

--- a/service/project/FileState.kt
+++ b/service/project/FileState.kt
@@ -187,9 +187,14 @@ class FileState internal constructor(
         watchFileSystem.set(false)
     }
 
-    override fun mayOpenAndRun(content: String) {
+    override fun mayOpenAndRun() {
+        if (!isRunnable || (!isOpen && !tryOpen())) return
+        mayRunSnippet(runContent)
+    }
+
+    fun mayRunSnippet(snippet: String) {
         if (!isOpen && !tryOpen()) return
-        projectSrv.client.run(content)?.let { runners.launched(it) }
+        projectSrv.client.run(snippet)?.let { runners.launched(it) }
     }
 
     fun isChanged() {


### PR DESCRIPTION
## What is the goal of this PR?

We allow the running of a selected query from non-TypeQL files.

## What are the changes implemented in this PR?

We no longer check whether a selection is from a TypeQL file before running it.

Closes https://github.com/vaticle/typedb-studio/issues/649
