### PR TITLE
Remove export schema button from database manager, unused kotlin loggers

### DIFF
--- a/framework/editor/TextRendering.kt
+++ b/framework/editor/TextRendering.kt
@@ -39,10 +39,6 @@ internal class TextRendering {
 
     private var results = initResults(0)
 
-    companion object {
-        private val LOGGER = KotlinLogging.logger {}
-    }
-
     private fun initResults(initSize: Int): SnapshotStateList<TextLayoutResult?> =
         mutableStateListOf<TextLayoutResult?>().apply { addAll(List(initSize) { null }) }
 

--- a/framework/graph/GraphArea.kt
+++ b/framework/graph/GraphArea.kt
@@ -64,7 +64,6 @@ class GraphArea(transactionState: TransactionState) {
     var theme: Color.GraphTheme? = null
     var typography: Typography.Theme? = null
     internal val textRenderer = TextRenderer(viewport)
-    private val LOGGER = KotlinLogging.logger {}
 
     companion object {
         val MIN_WIDTH = 120.dp

--- a/framework/material/BUILD
+++ b/framework/material/BUILD
@@ -42,7 +42,6 @@ kt_jvm_library(
         "@vaticle_typedb_common//:common",
 
         # External Maven Dependencies
-        "@maven//:io_github_microutils_kotlin_logging_jvm",
         "@maven//:org_jetbrains_compose_animation_animation_core_desktop",
         "@maven//:org_jetbrains_compose_foundation_foundation_desktop",
         "@maven//:org_jetbrains_compose_foundation_foundation_layout_desktop",

--- a/framework/material/ContextMenu.kt
+++ b/framework/material/ContextMenu.kt
@@ -76,7 +76,6 @@ object ContextMenu {
     private val ITEM_PADDING = 6.dp
     private val ITEM_SPACING = 20.dp
     private val POPUP_SHADOW = 12.dp
-    private val LOGGER = KotlinLogging.logger {}
 
     data class Item(
         val label: String,

--- a/module/connection/BUILD
+++ b/module/connection/BUILD
@@ -38,7 +38,6 @@ kt_jvm_library(
         "//framework/material:material",
 
         # External Maven Dependencies
-        "@maven//:io_github_microutils_kotlin_logging_jvm",
         "@maven//:org_jetbrains_compose_foundation_foundation_desktop",
         "@maven//:org_jetbrains_compose_foundation_foundation_layout_desktop",
         "@maven//:org_jetbrains_compose_runtime_runtime_desktop",

--- a/module/connection/DatabaseDialog.kt
+++ b/module/connection/DatabaseDialog.kt
@@ -114,25 +114,6 @@ object DatabaseDialog {
         buttonsFn = { databaseName ->
             listOf(
                 IconButtonArg(
-                    icon = Icon.EXPORT,
-                    enabled = Service.project.current != null && !Service.schema.hasRunningCommand,
-                    tooltip = Tooltip.Arg(title = Label.EXPORT_SCHEMA)
-                ) {
-                    try {
-                        Service.client.tryFetchSchema(databaseName).let { schema ->
-                            schema?.let {
-                                Service.project.tryCreateUntitledFile()?.let { file ->
-                                    file.content(schema)
-                                    file.tryOpen()
-                                }
-                            }
-                        }
-                    } catch (e: Exception) {
-                        Service.notification.systemError(LOGGER, e, FAILED_TO_LOAD_SCHEMA, databaseName, e.message ?: UNKNOWN)
-                        Service.client.refreshDatabaseList()
-                    }
-                },
-                IconButtonArg(
                     icon = Icon.DELETE,
                     color = { Theme.studio.errorStroke }
                 ) {

--- a/module/connection/DatabaseDialog.kt
+++ b/module/connection/DatabaseDialog.kt
@@ -61,7 +61,6 @@ object DatabaseDialog {
     private val MANAGER_HEIGHT = 500.dp
     private val SELECTOR_WIDTH = 400.dp
     private val SELECTOR_HEIGHT = 200.dp
-    private val LOGGER = KotlinLogging.logger {}
 
     private object CreateDatabaseForm : Form.State() {
         var name: String by mutableStateOf("")

--- a/module/connection/DatabaseDialog.kt
+++ b/module/connection/DatabaseDialog.kt
@@ -52,8 +52,6 @@ import com.vaticle.typedb.studio.framework.material.Icon
 import com.vaticle.typedb.studio.framework.material.Tooltip
 import com.vaticle.typedb.studio.service.Service
 import com.vaticle.typedb.studio.service.common.util.Label
-import com.vaticle.typedb.studio.service.common.util.Message.Companion.UNKNOWN
-import com.vaticle.typedb.studio.service.common.util.Message.Connection.Companion.FAILED_TO_LOAD_SCHEMA
 import com.vaticle.typedb.studio.service.common.util.Sentence
 import mu.KotlinLogging
 

--- a/module/project/ProjectBrowser.kt
+++ b/module/project/ProjectBrowser.kt
@@ -49,10 +49,6 @@ import mu.KotlinLogging
 
 class ProjectBrowser(initOpen: Boolean = false, order: Int) : Browsers.Browser(initOpen, order) {
 
-    companion object {
-        private val LOGGER = KotlinLogging.logger {}
-    }
-
     override val label: String = Label.PROJECT
     override val icon: Icon = Icon.FOLDER
     override val isActive: Boolean get() = Service.project.current != null

--- a/module/type/BUILD
+++ b/module/type/BUILD
@@ -42,7 +42,6 @@ kt_jvm_library(
         "@vaticle_typedb_common//:common",
 
         # External Maven Dependencies
-        "@maven//:io_github_microutils_kotlin_logging_jvm",
         "@maven//:org_jetbrains_compose_foundation_foundation_desktop",
         "@maven//:org_jetbrains_compose_foundation_foundation_layout_desktop",
         "@maven//:org_jetbrains_compose_runtime_runtime_desktop",

--- a/module/type/TypePage.kt
+++ b/module/type/TypePage.kt
@@ -127,8 +127,6 @@ sealed class TypePage<T : ThingType, TS : ThingTypeState<T, TS>> constructor(
         private val EMPTY_BOX_HEIGHT = Table.ROW_HEIGHT
         private const val MAX_VISIBLE_SUBTYPES = 10
 
-        private val LOGGER = KotlinLogging.logger {}
-
         fun create(type: ThingTypeState<*, *>): TypePage<*, *> {
             return when (type) {
                 is EntityTypeState -> Entity(type)

--- a/service/page/BUILD
+++ b/service/page/BUILD
@@ -33,7 +33,6 @@ kt_jvm_library(
         "//service/connection:connection",
 
         # External Maven Dependencies
-        "@maven//:io_github_microutils_kotlin_logging_jvm",
         "@maven//:org_jetbrains_compose_runtime_runtime_desktop",
         "@maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core_jvm",
         "@maven//:org_slf4j_slf4j_api",

--- a/service/page/PageService.kt
+++ b/service/page/PageService.kt
@@ -31,10 +31,6 @@ class PageService {
     val next: Pageable get() = opened[(opened.indexOf(active) + 1).mod(opened.size)]
     val previous: Pageable get() = opened[(opened.indexOf(active) - 1).mod(opened.size)]
 
-    companion object {
-        private val LOGGER = KotlinLogging.logger {}
-    }
-
     fun opened(pageable: Pageable, index: Int? = null) {
         val i = index ?: opened.size
         if (pageable !in opened) opened.add(i.coerceIn(0, (opened.size).coerceAtLeast(0)), pageable)

--- a/service/project/PathState.kt
+++ b/service/project/PathState.kt
@@ -44,10 +44,6 @@ sealed class PathState constructor(
         FILE(1);
     }
 
-    companion object {
-        private val LOGGER = KotlinLogging.logger {}
-    }
-
     private val hash = Objects.hash(path)
     override val name = path.fileName.toString()
     override val info = if (path.isSymbolicLink()) "→ " + path.readSymbolicLink().toString() else null

--- a/service/schema/AttributeTypeState.kt
+++ b/service/schema/AttributeTypeState.kt
@@ -52,10 +52,6 @@ class AttributeTypeState internal constructor(
         val isKey: Boolean,
     )
 
-    companion object {
-        private val LOGGER = KotlinLogging.logger {}
-    }
-
     override val info get() = valueType?.name?.lowercase()
     override val parent: AttributeTypeState? get() = supertype
 

--- a/service/schema/EntityTypeState.kt
+++ b/service/schema/EntityTypeState.kt
@@ -29,10 +29,6 @@ class EntityTypeState internal constructor(
     schemaSrv: SchemaService
 ) : ThingTypeState<EntityType, EntityTypeState>(conceptType, supertype, Encoding.ENTITY_TYPE, schemaSrv) {
 
-    companion object {
-        private val LOGGER = KotlinLogging.logger {}
-    }
-
     override val parent: EntityTypeState? get() = supertype
 
     override fun isSameEncoding(conceptType: Type) = conceptType.isEntityType

--- a/service/schema/RoleTypeState.kt
+++ b/service/schema/RoleTypeState.kt
@@ -63,10 +63,6 @@ class RoleTypeState constructor(
         val isInherited: Boolean,
     )
 
-    companion object {
-        private val LOGGER = KotlinLogging.logger {}
-    }
-
     val scopedName get() = relationType.name + ":" + name
     var playerTypeProperties: List<PlayerTypeProperties> by mutableStateOf(emptyList())
     val playerTypes get() = playerTypeProperties.map { it.playerType }

--- a/test/integration/common/BUILD
+++ b/test/integration/common/BUILD
@@ -51,7 +51,6 @@ kt_jvm_library(
         "@vaticle_typeql//java/query:query",
 
         # External Maven Dependencies
-        "@maven//:io_github_microutils_kotlin_logging_jvm",
         "@maven//:junit_junit",
         "@maven//:org_jetbrains_compose_runtime_runtime_desktop",
         "@maven//:org_jetbrains_compose_ui_ui_test_desktop",

--- a/test/integration/common/StudioActions.kt
+++ b/test/integration/common/StudioActions.kt
@@ -51,7 +51,6 @@ import kotlinx.coroutines.runBlocking
 import mu.KotlinLogging
 
 object StudioActions {
-    private val LOGGER = KotlinLogging.logger {}
 
     suspend fun clickIcon(composeRule: ComposeContentTestRule, icon: Icon) {
         clickText(composeRule, icon.unicode)


### PR DESCRIPTION
## What is the goal of this PR?

We've removed the ability to export schema from the database manager, as this isn't the appropriate place for the functionality (the database manager is solely for the management of databases). We plan to reintroduce this functionality into the menu bar when it is implemented.

We've also removed many unusued Kotlin loggers.

## What are the changes implemented in this PR?

We've removed the export schema button from the database manager. 

We've removed unused Kotlin loggers.