### PR TITLE
Terminology update for Type Editor and Type Browser

### DIFF
--- a/Studio.kt
+++ b/Studio.kt
@@ -85,7 +85,7 @@ import com.vaticle.typedb.studio.module.project.ProjectBrowser
 import com.vaticle.typedb.studio.module.project.ProjectDialog
 import com.vaticle.typedb.studio.module.type.TypeBrowser
 import com.vaticle.typedb.studio.module.type.TypeDialog
-import com.vaticle.typedb.studio.module.type.TypePage
+import com.vaticle.typedb.studio.module.type.TypeEditor
 import com.vaticle.typedb.studio.service.Service
 import com.vaticle.typedb.studio.service.common.util.Label
 import com.vaticle.typedb.studio.service.common.util.Message
@@ -190,7 +190,7 @@ object Studio {
                             Pages.Layout(enabled = Service.project.current != null) {
                                 when (it) {
                                     is FileState -> FilePage.create(it)
-                                    is ThingTypeState<*, *> -> TypePage.create(it)
+                                    is ThingTypeState<*, *> -> TypeEditor.create(it)
                                     else -> throw IllegalStateException("Unrecognised pageable type")
                                 }
                             }

--- a/module/type/TypeBrowser.kt
+++ b/module/type/TypeBrowser.kt
@@ -48,7 +48,7 @@ import com.vaticle.typedb.studio.service.schema.ThingTypeState
 
 class TypeBrowser(isOpen: Boolean = false, order: Int) : Browsers.Browser(isOpen, order) {
 
-    override val label: String = Label.TYPES
+    override val label: String = Label.TYPE_BROWSER
     override val icon: Icon = Icon.TYPES
     override val isActive: Boolean get() = Service.client.isConnected && Service.client.session.isOpen
     override var buttons: List<IconButtonArg> by mutableStateOf(emptyList())

--- a/module/type/TypeEditor.kt
+++ b/module/type/TypeEditor.kt
@@ -85,9 +85,8 @@ import com.vaticle.typedb.studio.service.schema.ThingTypeState
 import com.vaticle.typedb.studio.service.schema.TypeState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import mu.KotlinLogging
 
-sealed class TypePage<T : ThingType, TS : ThingTypeState<T, TS>> constructor(
+sealed class TypeEditor<T : ThingType, TS : ThingTypeState<T, TS>> constructor(
     var typeState: TS, showAdvanced: Boolean = false
 ) : Pages.Page() {
 
@@ -127,7 +126,7 @@ sealed class TypePage<T : ThingType, TS : ThingTypeState<T, TS>> constructor(
         private val EMPTY_BOX_HEIGHT = Table.ROW_HEIGHT
         private const val MAX_VISIBLE_SUBTYPES = 10
 
-        fun create(type: ThingTypeState<*, *>): TypePage<*, *> {
+        fun create(type: ThingTypeState<*, *>): TypeEditor<*, *> {
             return when (type) {
                 is EntityTypeState -> Entity(type)
                 is RelationTypeState -> Relation(type)
@@ -629,7 +628,7 @@ sealed class TypePage<T : ThingType, TS : ThingTypeState<T, TS>> constructor(
         )
     }
 
-    class Entity constructor(typeState: EntityTypeState) : TypePage<EntityType, EntityTypeState>(
+    class Entity constructor(typeState: EntityTypeState) : TypeEditor<EntityType, EntityTypeState>(
         typeState = typeState, showAdvanced = false
     ) {
 
@@ -644,7 +643,7 @@ sealed class TypePage<T : ThingType, TS : ThingTypeState<T, TS>> constructor(
         }
     }
 
-    class Relation constructor(typeState: RelationTypeState) : TypePage<RelationType, RelationTypeState>(
+    class Relation constructor(typeState: RelationTypeState) : TypeEditor<RelationType, RelationTypeState>(
         typeState = typeState, showAdvanced = typeState.playedRoleTypes.isNotEmpty()
     ) {
 
@@ -755,7 +754,7 @@ sealed class TypePage<T : ThingType, TS : ThingTypeState<T, TS>> constructor(
         }
     }
 
-    class Attribute constructor(typeState: AttributeTypeState) : TypePage<AttributeType, AttributeTypeState>(
+    class Attribute constructor(typeState: AttributeTypeState) : TypeEditor<AttributeType, AttributeTypeState>(
         typeState = typeState,
         showAdvanced = typeState.ownedAttTypes.isNotEmpty() || typeState.playedRoleTypes.isNotEmpty()
     ) {


### PR DESCRIPTION
## What is the goal of this PR?

We've renamed two parts of our system that pertain to the displaying of information about types. 

## What are the changes implemented in this PR?

  - Rename `TypePage` -> `Type Editor`
  - Rename tab "Types" -> "Type Browser"