### PR TITLE
Build 'has' edges in graph from query

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -52,6 +52,7 @@ build:
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel test $(bazel query 'kind(kt_jvm_test, //...) except kind(kt_jvm_test, //test/...)') --test_output=errors
     test-integration:
+      machine: 8-core-32-gb
       image: vaticle-ubuntu-22.04
       dependencies:
         - build

--- a/framework/graph/Edge.kt
+++ b/framework/graph/Edge.kt
@@ -41,16 +41,16 @@ sealed class Edge(open val source: Vertex, open val target: Vertex) {
     }
 
     // Type edges
-    class Sub(override val source: Vertex.Type, override val target: Vertex.Type) : Edge(source, target) {
+    data class Sub(override val source: Vertex.Type, override val target: Vertex.Type) : Edge(source, target) {
         override val label = Labels.SUB
     }
 
-    class Owns(override val source: Vertex.Type, override val target: Vertex.Type.Attribute) :
+    data class Owns(override val source: Vertex.Type, override val target: Vertex.Type.Attribute) :
         Edge(source, target) {
         override val label = Labels.OWNS
     }
 
-    class Plays(
+    data class Plays(
         override val source: Vertex.Type.Relation, override val target: Vertex.Type, private val role: String
     ) : Edge(source, target) {
         override val label = role
@@ -64,7 +64,7 @@ sealed class Edge(open val source: Vertex, open val target: Vertex) {
         override val label = Labels.HAS
     }
 
-    class Roleplayer(
+    data class Roleplayer(
         override val source: Vertex.Thing.Relation, override val target: Vertex.Thing, val role: String,
         override val isInferred: Boolean = false
     ) : Edge(source, target), Inferrable {
@@ -72,11 +72,11 @@ sealed class Edge(open val source: Vertex, open val target: Vertex) {
     }
 
     // Thing-to-type edges
-    class Isa(override val source: Vertex.Thing, override val target: Vertex.Type) : Edge(source, target) {
+    data class Isa(override val source: Vertex.Thing, override val target: Vertex.Type) : Edge(source, target) {
         override val label = Labels.ISA
     }
 
-    class Geometry(private val edge: Edge) : com.vaticle.force.graph.api.Edge {
+    data class Geometry(private val edge: Edge) : com.vaticle.force.graph.api.Edge {
 
         val isCurved get() = edge.curvePoint != null
         val midpoint

--- a/framework/graph/Edge.kt
+++ b/framework/graph/Edge.kt
@@ -57,7 +57,7 @@ sealed class Edge(open val source: Vertex, open val target: Vertex) {
     }
 
     // Thing edges
-    class Has(
+    data class Has(
         override val source: Vertex.Thing, override val target: Vertex.Thing.Attribute,
         override val isInferred: Boolean = false
     ) : Edge(source, target), Inferrable {

--- a/framework/graph/Graph.kt
+++ b/framework/graph/Graph.kt
@@ -46,7 +46,7 @@ class Graph(private val interactions: Interactions) {
 
     private val _thingVertices: MutableMap<String, Vertex.Thing> = ConcurrentHashMap()
     private val _typeVertices: MutableMap<String, Vertex.Type> = ConcurrentHashMap()
-    private val _edges: MutableList<Edge> = Collections.synchronizedList(mutableListOf())
+    private val _edges: MutableSet<Edge> = Collections.synchronizedSet(mutableSetOf())
 
     val thingVertices: Map<String, Vertex.Thing> get() = _thingVertices
     val typeVertices: Map<String, Vertex.Type> get() = _typeVertices

--- a/framework/graph/GraphArea.kt
+++ b/framework/graph/GraphArea.kt
@@ -48,17 +48,18 @@ import com.vaticle.typedb.studio.framework.common.theme.Color
 import com.vaticle.typedb.studio.framework.common.theme.Theme
 import com.vaticle.typedb.studio.framework.common.theme.Typography
 import com.vaticle.typedb.studio.service.connection.TransactionState
+import com.vaticle.typeql.lang.query.TypeQLQuery
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import mu.KotlinLogging
 
-class GraphArea(transactionState: TransactionState) {
+class GraphArea(transactionState: TransactionState, val query: TypeQLQuery) {
 
     val interactions = Interactions(this)
     val graph = Graph(interactions)
     val coroutines = CoroutineScope(Dispatchers.Default)
-    val graphBuilder = GraphBuilder(graph, transactionState, coroutines)
+    val graphBuilder = GraphBuilder(graph, query, transactionState, coroutines)
     val viewport = Viewport(graph)
     val physicsRunner = PhysicsRunner(this)
     var theme: Color.GraphTheme? = null

--- a/framework/graph/GraphBuilder.kt
+++ b/framework/graph/GraphBuilder.kt
@@ -84,10 +84,11 @@ class GraphBuilder(
                         if (answerSource is AnswerSource.Explanation) {
                             vertexExplanations += Pair(vertex, answerSource.explanation)
                         }
-                        when (vertex) {
-                            is Vertex.Thing.Attribute -> attributeVertices[varName] = vertex
-                            else -> nonAttributeVertices[varName] = vertex
-                        }
+                    }
+                    when (vertex) {
+                        is Vertex.Thing.Attribute -> attributeVertices[varName] = vertex
+                        is Vertex.Thing -> nonAttributeVertices[varName] = vertex
+                        else -> {}
                     }
                 }
                 concept is ThingType && concept.isRoot -> { /* skip root thing types */
@@ -106,13 +107,14 @@ class GraphBuilder(
                 pattern.asVariable().constraints().forEach { constraint ->
                     if (constraint.isThing && constraint.asThing().isHas) {
                         val hasee = constraint.asThing().asHas().attribute().reference().name()
-                        addEdge(
-                            Edge.Has(
+                        if (nonAttributeVertices.containsKey(hasser) && attributeVertices.containsKey(hasee)) {
+                            val edge = Edge.Has(
                                 nonAttributeVertices[hasser]!!,
                                 attributeVertices[hasee]!! as Vertex.Thing.Attribute,
                                 false
                             )
-                        )
+                            addEdge(edge)
+                        }
                     }
                 }
             }

--- a/framework/graph/GraphBuilder.kt
+++ b/framework/graph/GraphBuilder.kt
@@ -100,12 +100,20 @@ class GraphBuilder(
                 else -> throw unsupportedEncodingException(concept)
             }
         }
-        query.asMatch().conjunction().patterns().forEach {pattern ->
-            val hasser = pattern.asVariable().reference().name()
-            pattern.asVariable().constraints().forEach { constraint ->
-                if (constraint.isThing && constraint.asThing().isHas) {
-                    val hasee = constraint.asThing().asHas().attribute().reference().name()
-                    addEdge(Edge.Has(nonAttributeVertices[hasser]!!, attributeVertices[hasee] as Vertex.Thing.Attribute, false))
+        if (!Service.preference.connectedQueries) {
+            query.asMatch().conjunction().patterns().forEach { pattern ->
+                val hasser = pattern.asVariable().reference().name()
+                pattern.asVariable().constraints().forEach { constraint ->
+                    if (constraint.isThing && constraint.asThing().isHas) {
+                        val hasee = constraint.asThing().asHas().attribute().reference().name()
+                        addEdge(
+                            Edge.Has(
+                                nonAttributeVertices[hasser]!!,
+                                attributeVertices[hasee]!! as Vertex.Thing.Attribute,
+                                false
+                            )
+                        )
+                    }
                 }
             }
         }

--- a/framework/graph/GraphBuilder.kt
+++ b/framework/graph/GraphBuilder.kt
@@ -320,7 +320,7 @@ class GraphBuilder(
 
             override fun build() {
                 loadIsaEdge()
-                loadHasEdges()
+                if (Service.preference.connectedQueries) loadHasEdges()
                 if (thing is Relation) loadRoleplayerEdgesAndVertices()
             }
 

--- a/framework/graph/GraphVisualiser.kt
+++ b/framework/graph/GraphVisualiser.kt
@@ -28,10 +28,11 @@ import com.vaticle.typedb.studio.framework.material.Frame
 import com.vaticle.typedb.studio.framework.material.Separator
 import com.vaticle.typedb.studio.framework.material.Tabs
 import com.vaticle.typedb.studio.service.connection.TransactionState
+import com.vaticle.typeql.lang.query.TypeQLQuery
 
-class GraphVisualiser constructor(transactionState: TransactionState) {
+class GraphVisualiser constructor(transactionState: TransactionState, val query: TypeQLQuery) {
 
-    private val graphArea = GraphArea(transactionState)
+    private val graphArea = GraphArea(transactionState, query)
     private val browsers: List<Browsers.Browser> = listOf(ConceptPreview(graphArea, 0, false))
     private var frameState: Frame.FrameState = Frame.createFrameState(
         separator = Frame.SeparatorArgs(Separator.WEIGHT),

--- a/framework/output/GraphOutput.kt
+++ b/framework/output/GraphOutput.kt
@@ -26,10 +26,11 @@ import com.vaticle.typedb.studio.framework.material.Form
 import com.vaticle.typedb.studio.framework.material.Icon
 import com.vaticle.typedb.studio.service.common.util.Label
 import com.vaticle.typedb.studio.service.connection.TransactionState
+import com.vaticle.typeql.lang.query.TypeQLQuery
 
-internal class GraphOutput constructor(transactionState: TransactionState, number: Int) : RunOutput() {
+internal class GraphOutput constructor(transactionState: TransactionState, query: TypeQLQuery, number: Int) : RunOutput() {
 
-    private val graphVisualiser = GraphVisualiser(transactionState)
+    private val graphVisualiser = GraphVisualiser(transactionState, query)
 
     override val name: String = "${Label.GRAPH} ($number)"
     override val icon: Icon = Icon.GRAPH

--- a/framework/output/RunOutputGroup.kt
+++ b/framework/output/RunOutputGroup.kt
@@ -32,7 +32,7 @@ import com.vaticle.typedb.studio.service.common.StatusService.Key.OUTPUT_RESPONS
 import com.vaticle.typedb.studio.service.common.StatusService.Key.QUERY_RESPONSE_TIME
 import com.vaticle.typedb.studio.service.connection.QueryRunner
 import com.vaticle.typedb.studio.service.connection.QueryRunner.Response
-import com.vaticle.typedb.studio.service.connection.QueryRunner.Response.Stream.ConceptMaps.Source.MATCH
+import com.vaticle.typedb.studio.service.connection.QueryRunner.Response.Stream.ConceptMapsWithQuery.Source.MATCH
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.LinkedBlockingQueue
@@ -167,7 +167,7 @@ internal class RunOutputGroup constructor(
         is Response.Stream<*> -> when (response) {
             is Response.Stream.NumericGroups -> consumeNumericGroupStreamResponse(response)
             is Response.Stream.ConceptMapGroups -> consumeConceptMapGroupStreamResponse(response)
-            is Response.Stream.ConceptMaps -> consumeConceptMapStreamResponse(response)
+            is Response.Stream.ConceptMapsWithQuery -> consumeConceptMapStreamResponse(response)
         }
         is Response.Done -> {}
     }
@@ -192,7 +192,7 @@ internal class RunOutputGroup constructor(
         collectSerial(launchCompletableFuture(Service.notification, LOGGER) { logOutput.outputFn(it) })
     }
 
-    private suspend fun consumeConceptMapStreamResponse(response: Response.Stream.ConceptMaps) {
+    private suspend fun consumeConceptMapStreamResponse(response: Response.Stream.ConceptMapsWithQuery) {
         val notificationSrv = Service.notification
         // TODO: enable configuration of displaying GraphOutput for INSERT and UPDATE
         val table = if (response.source != MATCH) null else TableOutput(

--- a/framework/output/RunOutputGroup.kt
+++ b/framework/output/RunOutputGroup.kt
@@ -200,7 +200,7 @@ internal class RunOutputGroup constructor(
         ) // TODO: .also { outputs.add(it) }
         val graph =
             if (response.source != MATCH || !Service.preference.graphOutputEnabled) null else GraphOutput(
-                transactionState = runner.transactionState, number = graphCount.incrementAndGet()
+                transactionState = runner.transactionState, query = response.query, number = graphCount.incrementAndGet()
             ).also { outputs.add(it); activate(it) }
 
         consumeStreamResponse(response, onCompleted = { graph?.setCompleted() }) {

--- a/module/preference/PreferenceDialog.kt
+++ b/module/preference/PreferenceDialog.kt
@@ -382,12 +382,16 @@ object PreferenceDialog {
 
             override fun submit() {
                 preferenceSrv.graphOutputEnabled = graphOutput.value
+                preferenceSrv.connectedQueries = connectedQueries.value
                 graphOutput.modified = false
+                connectedQueries.modified = false
             }
 
             override fun reset() {
                 graphOutput.value = preferenceSrv.graphOutputEnabled
+                connectedQueries.value = preferenceSrv.connectedQueries
                 graphOutput.modified = false
+                connectedQueries.modified = false
             }
         }
 

--- a/module/preference/PreferenceDialog.kt
+++ b/module/preference/PreferenceDialog.kt
@@ -65,7 +65,7 @@ import com.vaticle.typedb.studio.service.Service
 import com.vaticle.typedb.studio.service.common.util.Label
 import com.vaticle.typedb.studio.service.common.util.Label.APPLY
 import com.vaticle.typedb.studio.service.common.util.Label.CANCEL
-import com.vaticle.typedb.studio.service.common.util.Label.ENABLE_CONNECTED_QUERIES
+import com.vaticle.typedb.studio.service.common.util.Label.ENABLE_EXTRA_CONNECTED_QUERIES
 import com.vaticle.typedb.studio.service.common.util.Label.ENABLE_EDITOR_AUTOSAVE
 import com.vaticle.typedb.studio.service.common.util.Label.ENABLE_GRAPH_OUTPUT
 import com.vaticle.typedb.studio.service.common.util.Label.GRAPH_VISUALISER
@@ -78,7 +78,7 @@ import com.vaticle.typedb.studio.service.common.util.Label.RESET
 import com.vaticle.typedb.studio.service.common.util.Label.SET_QUERY_LIMIT
 import com.vaticle.typedb.studio.service.common.util.Label.TEXT_EDITOR
 import com.vaticle.typedb.studio.service.common.util.Label.TRANSACTION_TIMEOUT_MINS
-import com.vaticle.typedb.studio.service.common.util.Sentence.PREFERENCES_CONNECTED_QUERIES_CAPTION
+import com.vaticle.typedb.studio.service.common.util.Sentence.PREFERENCES_EXTRA_CONNECTED_QUERIES_CAPTION
 import com.vaticle.typedb.studio.service.common.util.Sentence.PREFERENCES_GRAPH_OUTPUT_CAPTION
 import com.vaticle.typedb.studio.service.common.util.Sentence.PREFERENCES_IGNORED_PATHS_CAPTION
 import com.vaticle.typedb.studio.service.common.util.Sentence.PREFERENCES_MATCH_QUERY_LIMIT_CAPTION
@@ -373,25 +373,25 @@ object PreferenceDialog {
                 caption = PREFERENCES_GRAPH_OUTPUT_CAPTION
             )
 
-            private var connectedQueries = PreferenceField.Checkbox(
-                initValue = preferenceSrv.connectedQueries, label = ENABLE_CONNECTED_QUERIES,
-                caption = PREFERENCES_CONNECTED_QUERIES_CAPTION
+            private var extraConnectedQueries = PreferenceField.Checkbox(
+                initValue = preferenceSrv.extraConnectedQueries, label = ENABLE_EXTRA_CONNECTED_QUERIES,
+                caption = PREFERENCES_EXTRA_CONNECTED_QUERIES_CAPTION
             )
 
-            override val preferences: List<PreferenceField> = listOf(graphOutput, connectedQueries)
+            override val preferences: List<PreferenceField> = listOf(graphOutput, extraConnectedQueries)
 
             override fun submit() {
                 preferenceSrv.graphOutputEnabled = graphOutput.value
-                preferenceSrv.connectedQueries = connectedQueries.value
+                preferenceSrv.extraConnectedQueries = extraConnectedQueries.value
                 graphOutput.modified = false
-                connectedQueries.modified = false
+                extraConnectedQueries.modified = false
             }
 
             override fun reset() {
                 graphOutput.value = preferenceSrv.graphOutputEnabled
-                connectedQueries.value = preferenceSrv.connectedQueries
+                extraConnectedQueries.value = preferenceSrv.extraConnectedQueries
                 graphOutput.modified = false
-                connectedQueries.modified = false
+                extraConnectedQueries.modified = false
             }
         }
 

--- a/module/preference/PreferenceDialog.kt
+++ b/module/preference/PreferenceDialog.kt
@@ -65,6 +65,7 @@ import com.vaticle.typedb.studio.service.Service
 import com.vaticle.typedb.studio.service.common.util.Label
 import com.vaticle.typedb.studio.service.common.util.Label.APPLY
 import com.vaticle.typedb.studio.service.common.util.Label.CANCEL
+import com.vaticle.typedb.studio.service.common.util.Label.ENABLE_CONNECTED_QUERIES
 import com.vaticle.typedb.studio.service.common.util.Label.ENABLE_EDITOR_AUTOSAVE
 import com.vaticle.typedb.studio.service.common.util.Label.ENABLE_GRAPH_OUTPUT
 import com.vaticle.typedb.studio.service.common.util.Label.GRAPH_VISUALISER
@@ -77,6 +78,7 @@ import com.vaticle.typedb.studio.service.common.util.Label.RESET
 import com.vaticle.typedb.studio.service.common.util.Label.SET_QUERY_LIMIT
 import com.vaticle.typedb.studio.service.common.util.Label.TEXT_EDITOR
 import com.vaticle.typedb.studio.service.common.util.Label.TRANSACTION_TIMEOUT_MINS
+import com.vaticle.typedb.studio.service.common.util.Sentence.PREFERENCES_CONNECTED_QUERIES_CAPTION
 import com.vaticle.typedb.studio.service.common.util.Sentence.PREFERENCES_GRAPH_OUTPUT_CAPTION
 import com.vaticle.typedb.studio.service.common.util.Sentence.PREFERENCES_IGNORED_PATHS_CAPTION
 import com.vaticle.typedb.studio.service.common.util.Sentence.PREFERENCES_MATCH_QUERY_LIMIT_CAPTION
@@ -371,7 +373,12 @@ object PreferenceDialog {
                 caption = PREFERENCES_GRAPH_OUTPUT_CAPTION
             )
 
-            override val preferences: List<PreferenceField> = listOf(graphOutput)
+            private var connectedQueries = PreferenceField.Checkbox(
+                initValue = preferenceSrv.connectedQueries, label = ENABLE_CONNECTED_QUERIES,
+                caption = PREFERENCES_CONNECTED_QUERIES_CAPTION
+            )
+
+            override val preferences: List<PreferenceField> = listOf(graphOutput, connectedQueries)
 
             override fun submit() {
                 preferenceSrv.graphOutputEnabled = graphOutput.value

--- a/service/common/DataService.kt
+++ b/service/common/DataService.kt
@@ -104,6 +104,7 @@ class DataService {
         private val MATCH_QUERY_LIMIT = "query.match-limit"
         private val TRANSACTION_TIMEOUT_MINS = "query.transaction-timeout-mins"
         private val GRAPH_OUTPUT = "graph.output"
+        private val CONNECTED_QUERIES = "graph.connected-queries"
 
         var autoSave: Boolean?
             get() = properties?.getProperty(AUTO_SAVE)?.toBoolean()
@@ -124,6 +125,10 @@ class DataService {
         var graphOutputEnabled: Boolean?
             get() = properties?.getProperty(GRAPH_OUTPUT)?.toBoolean()
             set(value) = setProperty(GRAPH_OUTPUT, value.toString())
+
+        var connectedQueries: Boolean?
+            get() = properties?.getProperty(CONNECTED_QUERIES)?.toBoolean()
+            set(value) = setProperty(CONNECTED_QUERIES, value.toString())
     }
 
     var properties: Properties? by mutableStateOf(null)

--- a/service/common/DataService.kt
+++ b/service/common/DataService.kt
@@ -126,7 +126,7 @@ class DataService {
             get() = properties?.getProperty(GRAPH_OUTPUT)?.toBoolean()
             set(value) = setProperty(GRAPH_OUTPUT, value.toString())
 
-        var connectedQueries: Boolean?
+        var extraConnectedQueries: Boolean?
             get() = properties?.getProperty(CONNECTED_QUERIES)?.toBoolean()
             set(value) = setProperty(CONNECTED_QUERIES, value.toString())
     }

--- a/service/common/PreferenceService.kt
+++ b/service/common/PreferenceService.kt
@@ -35,9 +35,9 @@ class PreferenceService(dataSrv: DataService) {
         get() = preferences.graphOutputEnabled ?: field
         set(value) = run { preferences.graphOutputEnabled = value }
 
-    var connectedQueries: Boolean = Defaults.connectedQueries
-        get() = preferences.connectedQueries ?: field
-        set(value) = run { preferences.connectedQueries = value }
+    var extraConnectedQueries: Boolean = Defaults.extraConnectedQueries
+        get() = preferences.extraConnectedQueries ?: field
+        set(value) = run { preferences.extraConnectedQueries = value }
 
     var matchQueryLimit: Long = Defaults.matchQueryLimit
         get() = preferences.matchQueryLimit ?: field
@@ -63,7 +63,7 @@ class PreferenceService(dataSrv: DataService) {
 
     private object Defaults {
         val autoSave = true
-        val connectedQueries = false
+        val extraConnectedQueries = false
         val graphOutputEnabled = true
         val matchQueryLimit = 1000L
         val ignoredPaths = listOf(".git")

--- a/service/common/PreferenceService.kt
+++ b/service/common/PreferenceService.kt
@@ -35,6 +35,10 @@ class PreferenceService(dataSrv: DataService) {
         get() = preferences.graphOutputEnabled ?: field
         set(value) = run { preferences.graphOutputEnabled = value }
 
+    var connectedQueries: Boolean = Defaults.connectedQueries
+        get() = preferences.connectedQueries ?: field
+        set(value) = run { preferences.connectedQueries = value }
+
     var matchQueryLimit: Long = Defaults.matchQueryLimit
         get() = preferences.matchQueryLimit ?: field
         set(value) = run { preferences.matchQueryLimit = value }
@@ -59,6 +63,7 @@ class PreferenceService(dataSrv: DataService) {
 
     private object Defaults {
         val autoSave = true
+        val connectedQueries = true
         val graphOutputEnabled = true
         val matchQueryLimit = 1000L
         val ignoredPaths = listOf(".git")

--- a/service/common/PreferenceService.kt
+++ b/service/common/PreferenceService.kt
@@ -63,7 +63,7 @@ class PreferenceService(dataSrv: DataService) {
 
     private object Defaults {
         val autoSave = true
-        val connectedQueries = true
+        val connectedQueries = false
         val graphOutputEnabled = true
         val matchQueryLimit = 1000L
         val ignoredPaths = listOf(".git")

--- a/service/common/util/Label.kt
+++ b/service/common/util/Label.kt
@@ -86,6 +86,7 @@ object Label {
     const val DISCONNECT = "Disconnect"
     const val DISMISS_ALL = "Dismiss All"
     const val EDIT = "Edit"
+    const val ENABLE_CONNECTED_QUERIES = "Enable Connected Queries"
     const val ENABLE_EDITOR_AUTOSAVE = "Enable Autosave"
     const val ENABLE_GRAPH_OUTPUT = "Enable Graph Output"
     const val ENABLE_INFERENCE = "Enable Inference"

--- a/service/common/util/Label.kt
+++ b/service/common/util/Label.kt
@@ -86,7 +86,7 @@ object Label {
     const val DISCONNECT = "Disconnect"
     const val DISMISS_ALL = "Dismiss All"
     const val EDIT = "Edit"
-    const val ENABLE_CONNECTED_QUERIES = "Enable Connected Queries"
+    const val ENABLE_EXTRA_CONNECTED_QUERIES = "Extra Connected Queries"
     const val ENABLE_EDITOR_AUTOSAVE = "Enable Autosave"
     const val ENABLE_GRAPH_OUTPUT = "Enable Graph Output"
     const val ENABLE_INFERENCE = "Enable Inference"

--- a/service/common/util/Sentence.kt
+++ b/service/common/util/Sentence.kt
@@ -123,6 +123,8 @@ object Sentence {
                 "Additionally, you can export a database's schema."
     const val OUTPUT_RESPONSE_TIME_DESCRIPTION =
         "Duration to collect all answers of the query from the server."
+    const val PREFERENCES_CONNECTED_QUERIES_CAPTION =
+        "When running a match query, run extra queries to fully connect the graph."
     const val PREFERENCES_GRAPH_OUTPUT_CAPTION =
         "When running a match query, display a graph output."
     const val PREFERENCES_IGNORED_PATHS_CAPTION = "Ignore files matching glob expressions. Separate entries by line."

--- a/service/common/util/Sentence.kt
+++ b/service/common/util/Sentence.kt
@@ -123,7 +123,7 @@ object Sentence {
                 "Additionally, you can export a database's schema."
     const val OUTPUT_RESPONSE_TIME_DESCRIPTION =
         "Duration to collect all answers of the query from the server."
-    const val PREFERENCES_CONNECTED_QUERIES_CAPTION =
+    const val PREFERENCES_EXTRA_CONNECTED_QUERIES_CAPTION =
         "When running a match query, run extra queries to fully connect the graph."
     const val PREFERENCES_GRAPH_OUTPUT_CAPTION =
         "When running a match query, display a graph output."

--- a/service/connection/QueryRunner.kt
+++ b/service/connection/QueryRunner.kt
@@ -29,9 +29,9 @@ import com.vaticle.typedb.studio.service.connection.QueryRunner.Response.Message
 import com.vaticle.typedb.studio.service.connection.QueryRunner.Response.Message.Type.INFO
 import com.vaticle.typedb.studio.service.connection.QueryRunner.Response.Message.Type.SUCCESS
 import com.vaticle.typedb.studio.service.connection.QueryRunner.Response.Message.Type.TYPEQL
-import com.vaticle.typedb.studio.service.connection.QueryRunner.Response.Stream.ConceptMaps.Source.INSERT
-import com.vaticle.typedb.studio.service.connection.QueryRunner.Response.Stream.ConceptMaps.Source.MATCH
-import com.vaticle.typedb.studio.service.connection.QueryRunner.Response.Stream.ConceptMaps.Source.UPDATE
+import com.vaticle.typedb.studio.service.connection.QueryRunner.Response.Stream.ConceptMapsWithQuery.Source.INSERT
+import com.vaticle.typedb.studio.service.connection.QueryRunner.Response.Stream.ConceptMapsWithQuery.Source.MATCH
+import com.vaticle.typedb.studio.service.connection.QueryRunner.Response.Stream.ConceptMapsWithQuery.Source.UPDATE
 import com.vaticle.typeql.lang.TypeQL
 import com.vaticle.typeql.lang.query.TypeQLDefine
 import com.vaticle.typeql.lang.query.TypeQLDelete
@@ -74,7 +74,7 @@ class QueryRunner constructor(
 
             class ConceptMapGroups : Stream<ConceptMapGroup>()
             class NumericGroups : Stream<NumericGroup>()
-            class ConceptMaps constructor(val source: Source, val query: TypeQLQuery) : Stream<ConceptMap>() {
+            class ConceptMapsWithQuery constructor(val source: Source, val query: TypeQLQuery) : Stream<ConceptMap>() {
                 enum class Source { INSERT, UPDATE, MATCH }
             }
         }
@@ -199,7 +199,7 @@ class QueryRunner constructor(
         successMsg = INSERT_QUERY_SUCCESS,
         noResultMsg = INSERT_QUERY_NO_RESULT,
         queryStr = query.toString(),
-        stream = Response.Stream.ConceptMaps(INSERT, query)
+        stream = Response.Stream.ConceptMapsWithQuery(INSERT, query)
     ) { transaction.query().insert(query, transactionState.defaultTypeDBOptions().prefetch(true)) }
 
     private fun runUpdateQuery(query: TypeQLUpdate) = runStreamingQuery(
@@ -207,7 +207,7 @@ class QueryRunner constructor(
         successMsg = UPDATE_QUERY_SUCCESS,
         noResultMsg = UPDATE_QUERY_NO_RESULT,
         queryStr = query.toString(),
-        stream = Response.Stream.ConceptMaps(UPDATE, query)
+        stream = Response.Stream.ConceptMapsWithQuery(UPDATE, query)
     ) { transaction.query().update(query, transactionState.defaultTypeDBOptions().prefetch(true)) }
 
     private fun runMatchQuery(query: TypeQLMatch) = runStreamingQuery(
@@ -215,7 +215,7 @@ class QueryRunner constructor(
         successMsg = MATCH_QUERY_SUCCESS,
         noResultMsg = MATCH_QUERY_NO_RESULT,
         queryStr = query.toString(),
-        stream = Response.Stream.ConceptMaps(MATCH, query)
+        stream = Response.Stream.ConceptMapsWithQuery(MATCH, query)
     ) {
         if (query.modifiers().limit().isPresent) {
             transaction.query().match(query)

--- a/service/connection/QueryRunner.kt
+++ b/service/connection/QueryRunner.kt
@@ -265,7 +265,7 @@ class QueryRunner constructor(
         queryFn: () -> Stream<T>
     ) {
         printQueryStart(name, queryStr)
-        collectResponseStream(queryFn(), queryStr, successMsg, noResultMsg, stream)
+        collectResponseStream(queryFn(), successMsg, noResultMsg, stream)
     }
 
     private fun printQueryStart(name: String, queryStr: String) {
@@ -276,7 +276,6 @@ class QueryRunner constructor(
 
     private fun <T : Any> collectResponseStream(
         results: Stream<T>,
-        queryStr: String,
         successMsg: String,
         noResultMsg: String,
         stream: Response.Stream<T>


### PR DESCRIPTION
## What is the goal of this PR?

We've refactored the graph building process to include the ability to derive 'has' edges from the query constraints.

We've gated the previous behaviour behind a preference 'Enable Extra Connectedness Queries'

## What are the changes implemented in this PR?

We've added:
* a preference for performing the extra connectedness queries, set to false by default.
* functionality to build has edges from the query constraints in the event the above preference is disabled.
