### PR TITLE
Refactor schema vertex rendering for graph visualisation

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -1,71 +1,71 @@
+##
+## Copyright (C) 2022 Vaticle
+##
+## This program is free software: you can redistribute it and/or modify
+## it under the terms of the GNU Affero General Public License as
+## published by the Free Software Foundation, either version 3 of the
+## License, or (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU Affero General Public License for more details.
+##
+## You should have received a copy of the GNU Affero General Public License
+## along with this program.  If not, see <https://www.gnu.org/licenses/>.
+##
 #
-# Copyright (C) 2022 Vaticle
+#config:
+#  version-candidate: VERSION
+#  dependencies:
+#    dependencies: [ build ]
+#    typedb-client-java: [ build, release ]
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as
-# published by the Free Software Foundation, either version 3 of the
-# License, or (at your option) any later version.
+#build:
+#  quality:
+#    filter:
+#      owner: vaticle
+#      branch: master
+#    dependency-analysis:
+#      image: vaticle-ubuntu-22.04
+#      command: |
+#        bazel run @vaticle_dependencies//factory/analysis:dependency-analysis
+#  correctness:
+#    build:
+#      image: vaticle-ubuntu-22.04
+#      command: |
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel build //...
+#        bazel run @vaticle_dependencies//tool/checkstyle:test-coverage
+#        bazel test $(bazel query 'kind(checkstyle_test, //...)') --test_output=errors
+#    build-dependency:
+#      image: vaticle-ubuntu-22.04
+#      command: |
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        dependencies/maven/update.sh
+#        git diff --exit-code dependencies/maven/artifacts.snapshot
+#    test-unit:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      command: |
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel test $(bazel query 'kind(kt_jvm_test, //...) except kind(kt_jvm_test, //test/...)') --test_output=errors
+#    test-integration:
+#      machine: 8-core-32-gb
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      command: |
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel build //test/integration/...
+#        bazel test $(bazel query '//test/integration/... except kind(checkstyle_test, //test/integration/...)') --jobs=1 --spawn_strategy=local --test_output=errors
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
-#
-
-config:
-  version-candidate: VERSION
-  dependencies:
-    dependencies: [ build ]
-    typedb-client-java: [ build, release ]
-
-build:
-  quality:
-    filter:
-      owner: vaticle
-      branch: master
-    dependency-analysis:
-      image: vaticle-ubuntu-22.04
-      command: |
-        bazel run @vaticle_dependencies//factory/analysis:dependency-analysis
-  correctness:
-    build:
-      image: vaticle-ubuntu-22.04
-      command: |
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel build //...
-        bazel run @vaticle_dependencies//tool/checkstyle:test-coverage
-        bazel test $(bazel query 'kind(checkstyle_test, //...)') --test_output=errors
-    build-dependency:
-      image: vaticle-ubuntu-22.04
-      command: |
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        dependencies/maven/update.sh
-        git diff --exit-code dependencies/maven/artifacts.snapshot
-    test-unit:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      command: |
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel test $(bazel query 'kind(kt_jvm_test, //...) except kind(kt_jvm_test, //test/...)') --test_output=errors
-    test-integration:
-      machine: 8-core-32-gb
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      command: |
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel build //test/integration/...
-        bazel test $(bazel query '//test/integration/... except kind(checkstyle_test, //test/integration/...)') --jobs=1 --spawn_strategy=local --test_output=errors
-
-release:
-  deployment:
-    trigger-release-circleci:
-      image: vaticle-ubuntu-22.04
-      command: |
-        git checkout -b release
-        git push -f origin release
-        echo "Successfully pushed branch 'release', which triggers a release workflow in CircleCI. The progress of the release can be tracked there."
+#release:
+#  deployment:
+#    trigger-release-circleci:
+#      image: vaticle-ubuntu-22.04
+#      command: |
+#        git checkout -b release
+#        git push -f origin release
+#        echo "Successfully pushed branch 'release', which triggers a release workflow in CircleCI. The progress of the release can be tracked there."

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -1,71 +1,71 @@
-##
-## Copyright (C) 2022 Vaticle
-##
-## This program is free software: you can redistribute it and/or modify
-## it under the terms of the GNU Affero General Public License as
-## published by the Free Software Foundation, either version 3 of the
-## License, or (at your option) any later version.
-##
-## This program is distributed in the hope that it will be useful,
-## but WITHOUT ANY WARRANTY; without even the implied warranty of
-## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-## GNU Affero General Public License for more details.
-##
-## You should have received a copy of the GNU Affero General Public License
-## along with this program.  If not, see <https://www.gnu.org/licenses/>.
-##
 #
-#config:
-#  version-candidate: VERSION
-#  dependencies:
-#    dependencies: [ build ]
-#    typedb-client-java: [ build, release ]
+# Copyright (C) 2022 Vaticle
 #
-#build:
-#  quality:
-#    filter:
-#      owner: vaticle
-#      branch: master
-#    dependency-analysis:
-#      image: vaticle-ubuntu-22.04
-#      command: |
-#        bazel run @vaticle_dependencies//factory/analysis:dependency-analysis
-#  correctness:
-#    build:
-#      image: vaticle-ubuntu-22.04
-#      command: |
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel build //...
-#        bazel run @vaticle_dependencies//tool/checkstyle:test-coverage
-#        bazel test $(bazel query 'kind(checkstyle_test, //...)') --test_output=errors
-#    build-dependency:
-#      image: vaticle-ubuntu-22.04
-#      command: |
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        dependencies/maven/update.sh
-#        git diff --exit-code dependencies/maven/artifacts.snapshot
-#    test-unit:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      command: |
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel test $(bazel query 'kind(kt_jvm_test, //...) except kind(kt_jvm_test, //test/...)') --test_output=errors
-#    test-integration:
-#      machine: 8-core-32-gb
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      command: |
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel build //test/integration/...
-#        bazel test $(bazel query '//test/integration/... except kind(checkstyle_test, //test/integration/...)') --jobs=1 --spawn_strategy=local --test_output=errors
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
 #
-#release:
-#  deployment:
-#    trigger-release-circleci:
-#      image: vaticle-ubuntu-22.04
-#      command: |
-#        git checkout -b release
-#        git push -f origin release
-#        echo "Successfully pushed branch 'release', which triggers a release workflow in CircleCI. The progress of the release can be tracked there."
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+config:
+  version-candidate: VERSION
+  dependencies:
+    dependencies: [ build ]
+    typedb-client-java: [ build, release ]
+
+build:
+  quality:
+    filter:
+      owner: vaticle
+      branch: master
+    dependency-analysis:
+      image: vaticle-ubuntu-22.04
+      command: |
+        bazel run @vaticle_dependencies//factory/analysis:dependency-analysis
+  correctness:
+    build:
+      image: vaticle-ubuntu-22.04
+      command: |
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel build //...
+        bazel run @vaticle_dependencies//tool/checkstyle:test-coverage
+        bazel test $(bazel query 'kind(checkstyle_test, //...)') --test_output=errors
+    build-dependency:
+      image: vaticle-ubuntu-22.04
+      command: |
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        dependencies/maven/update.sh
+        git diff --exit-code dependencies/maven/artifacts.snapshot
+    test-unit:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel test $(bazel query 'kind(kt_jvm_test, //...) except kind(kt_jvm_test, //test/...)') --test_output=errors
+    test-integration:
+      machine: 8-core-32-gb
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel build //test/integration/...
+        bazel test $(bazel query '//test/integration/... except kind(checkstyle_test, //test/integration/...)') --jobs=1 --spawn_strategy=local --test_output=errors
+
+release:
+  deployment:
+    trigger-release-circleci:
+      image: vaticle-ubuntu-22.04
+      command: |
+        git checkout -b release
+        git push -f origin release
+        echo "Successfully pushed branch 'release', which triggers a release workflow in CircleCI. The progress of the release can be tracked there."

--- a/framework/graph/GraphBuilder.kt
+++ b/framework/graph/GraphBuilder.kt
@@ -430,7 +430,7 @@ class GraphBuilder(
             override fun build() {
                 loadSubEdge()
                 loadOwnsEdges()
-//                loadPlaysEdges()
+                loadPlaysEdges()
             }
 
             private fun loadSubEdge() {

--- a/framework/graph/GraphBuilder.kt
+++ b/framework/graph/GraphBuilder.kt
@@ -168,7 +168,7 @@ class GraphBuilder(
 
     private fun completeScopedEdgeCandidateEdges(edgeCandidates: Collection<ScopedEdgeCandidate>) {
         val candidates = edgeCandidates.distinctBy {
-            Pair(it.label, it.vertex)
+            it.distinctSelector
         }
         candidates.forEach {
             val typeVertex = allTypeVertices[it.label]
@@ -283,6 +283,7 @@ class GraphBuilder(
         abstract var supertypes: List<ThingType>
         abstract val label: String
         abstract val vertex: Vertex
+        abstract val distinctSelector: List<String>
         abstract fun toEdge(vertex: Vertex): Edge
         open fun rescope(supertype: Vertex.Type) {
             this.supertypes.apply {
@@ -296,6 +297,8 @@ class GraphBuilder(
                 get() = targetLabel
             override val vertex: Vertex
                 get() = source
+            override val distinctSelector: List<String>
+                get() = listOf(source.label, targetLabel)
             override fun toEdge(vertex: Vertex) =
                 Edge.Owns(source as Vertex.Type, vertex as Vertex.Type.Attribute)
 
@@ -310,6 +313,8 @@ class GraphBuilder(
                 get() = sourceLabel
             override val vertex: Vertex
                 get() = target
+            override val distinctSelector: List<String>
+                get() = listOf(sourceLabel, role.label.name(), target.label)
             override fun toEdge(vertex: Vertex) =
                 Edge.Plays(vertex as Vertex.Type.Relation, target, role.label.name())
 

--- a/framework/graph/GraphBuilder.kt
+++ b/framework/graph/GraphBuilder.kt
@@ -159,15 +159,27 @@ class GraphBuilder(
         // concurrently, we do a final sanity check once all vertices + edges have been loaded.
         lock.readLock().withLock {
             (graph.thingVertices + graph.typeVertices).values.forEach { completeEdges(it) }
-            ownsScopedEdgeCandidates.forEach { (_, u) -> u.forEach {
+            val ownsCands = ownsScopedEdgeCandidates.values.flatten().distinctBy {
+                Pair(it.source, it.targetLabel)
+            }
+            ownsCands.forEach {
                 val typeVertex = allTypeVertices[it.targetLabel]
-                if (typeVertex != null) edges.add(it.toEdge(typeVertex))
-            } }
+                if (typeVertex != null) {
+                    val edge = it.toEdge(typeVertex)
+                    edges.add(edge)
+                }
+            }
             ownsScopedEdgeCandidates.clear()
-            playsRoleScopedEdgeCandidate.forEach { (_, u) -> u.forEach {
+            val playsCands = playsRoleScopedEdgeCandidate.values.flatten().distinctBy {
+                Pair(it.sourceLabel, it.target)
+            }
+            playsCands.forEach {
                 val typeVertex = allTypeVertices[it.sourceLabel]
-                if (typeVertex != null) edges.add(it.toEdge(typeVertex))
-            }}
+                if (typeVertex != null) {
+                    val edge = it.toEdge(typeVertex)
+                    edges.add(edge)
+                }
+            }
             playsRoleScopedEdgeCandidate.clear()
         }
     }

--- a/framework/graph/GraphBuilder.kt
+++ b/framework/graph/GraphBuilder.kt
@@ -115,7 +115,7 @@ class GraphBuilder(
             if (added) {
                 newRecords[key] = v
                 completeEdges(missingVertex = v)
-                EdgeBuilder.of(concept, v, this, transactionState.transaction).build()
+                EdgeBuilder.of(concept, v, this, transactionState.transaction)?.build()
             }
             v
         }
@@ -352,13 +352,13 @@ class GraphBuilder(
         abstract fun build()
 
         companion object {
-            fun of(concept: Concept, vertex: Vertex, graphBuilder: GraphBuilder, transaction: TypeDBTransaction?): EdgeBuilder {
+            fun of(concept: Concept, vertex: Vertex, graphBuilder: GraphBuilder, transaction: TypeDBTransaction?): EdgeBuilder? {
                 return when (concept) {
                     is com.vaticle.typedb.client.api.concept.thing.Thing -> {
                         Thing(concept, vertex as Vertex.Thing, transaction, graphBuilder)
                     }
-                    is com.vaticle.typedb.client.api.concept.type.ThingType -> {
-                        ThingType(concept.asThingType(), vertex as Vertex.Type, transaction, graphBuilder)
+                    is ThingType -> {
+                        null
                     }
                     else -> throw graphBuilder.unsupportedEncodingException(concept)
                 }
@@ -429,18 +429,6 @@ class GraphBuilder(
                         }
                     }
                 }
-            }
-        }
-
-        class ThingType(
-            private val thingType: com.vaticle.typedb.client.api.concept.type.ThingType,
-            private val typeVertex: Vertex.Type,
-            private val transaction: TypeDBTransaction?,
-            ctx: GraphBuilder,
-            ) : EdgeBuilder(ctx) {
-            private val remoteThingType get() = transaction?.let { thingType.asRemote(it) }
-
-            override fun build() {
             }
         }
     }

--- a/framework/output/RunOutputGroup.kt
+++ b/framework/output/RunOutputGroup.kt
@@ -145,9 +145,9 @@ internal class RunOutputGroup constructor(
         while (futuresLatch.count > 0L) {
             delay(COUNT_DOWN_LATCH_PERIOD_MS)
         }
+        outputs.filterIsInstance<GraphOutput>().forEach { it.setCompleted() }
         runner.setConsumed()
         logOutput.stop()
-        outputs.filterIsInstance<GraphOutput>().forEach { it.setCompleted() }
         endTime = System.currentTimeMillis()
     }
 

--- a/framework/output/RunOutputGroup.kt
+++ b/framework/output/RunOutputGroup.kt
@@ -41,10 +41,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.joinAll
-import kotlinx.coroutines.runBlocking
 import mu.KotlinLogging
 
 internal class RunOutputGroup constructor(
@@ -150,7 +147,7 @@ internal class RunOutputGroup constructor(
         }
         runner.setConsumed()
         logOutput.stop()
-        if (active is GraphOutput) (active as GraphOutput).setCompleted()
+        outputs.filterIsInstance<GraphOutput>().forEach { it.setCompleted() }
         endTime = System.currentTimeMillis()
     }
 


### PR DESCRIPTION
## What is the goal of this PR?

Previously, Studio would visualise 'owns' edges that are inherited multiple times, even if the type from which it inherited this ownership is also present on the graph with its own 'owns' edge to the same attribute type.

Now, Studio only visualises owns, plays and sub edges for the 'super-est' edges that own, plays or are subtypes for those types that are visible on the graph.

## What are the changes implemented in this PR?

We've introduced a new methodology for rendering schema vertices that waits until all the vertices are loaded onto the graph before completely resolve which edges it should draw. 

We've also removed functionality that supposedly ran upon the `GraphBuilder` completing, but actually run as soon as the graph building process had started.