### PR TITLE
Bump the Java Client to 2.18

### DIFF
--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -42,5 +42,5 @@ def vaticle_typedb_client_java():
     git_repository(
         name = "vaticle_typedb_client_java",
         remote = "https://github.com/vaticle/typedb-client-java",
-        tag = "2.17.1",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_client_java
+        commit = "16c23649627001b44b39337f9d904619b4dac97c",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_client_java
     )

--- a/service/schema/AttributeTypeState.kt
+++ b/service/schema/AttributeTypeState.kt
@@ -21,9 +21,11 @@ package com.vaticle.typedb.studio.service.schema
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import com.vaticle.typedb.client.api.concept.Concept
 import com.vaticle.typedb.client.api.concept.type.AttributeType
 import com.vaticle.typedb.client.api.concept.type.ThingType
 import com.vaticle.typedb.client.api.concept.type.Type
+import com.vaticle.typeql.lang.common.TypeQLToken
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.streams.toList
 import mu.KotlinLogging
@@ -55,8 +57,8 @@ class AttributeTypeState internal constructor(
     override val info get() = valueType?.name?.lowercase()
     override val parent: AttributeTypeState? get() = supertype
 
-    val valueType: AttributeType.ValueType? = if (!conceptType.isRoot) conceptType.valueType else null
-    val isKeyable: Boolean get() = conceptType.valueType.isKeyable
+    val valueType: Concept.ValueType? = if (!conceptType.isRoot) conceptType.valueType else null
+    val isKeyable: Boolean get() = valueType.
     var ownerTypeProperties: List<AttTypeOwnerProperties> by mutableStateOf(listOf())
     val ownerTypes get() = ownerTypeProperties.map { it.ownerType }
     val ownerTypesExplicit get() = ownerTypeProperties.filter { !it.isInherited }.map { it.ownerType }
@@ -97,16 +99,16 @@ class AttributeTypeState internal constructor(
             val typeTx = conceptType.asRemote(tx)
             if (!loadedOwnerTypePropsAtomic.get()) {
                 loadedOwnerTypePropsAtomic.set(true)
-                typeTx.getOwnersExplicit(true).forEach {
+                typeTx.getOwnersExplicit(setOf(TypeQLToken.Annotation.KEY)).forEach {
                     load(it, isKey = true, isInherited = false)
                 }
-                typeTx.getOwnersExplicit(false).filter { !loaded.contains(it) }.forEach {
+                typeTx.getOwnersExplicit(setOf()).filter { !loaded.contains(it) }.forEach {
                     load(it, isKey = false, isInherited = false)
                 }
-                typeTx.getOwners(true).filter { !loaded.contains(it) }.forEach {
+                typeTx.getOwners(setOf(TypeQLToken.Annotation.KEY)).filter { !loaded.contains(it) }.forEach {
                     load(it, isKey = true, isInherited = true)
                 }
-                typeTx.getOwners(false).filter { !loaded.contains(it) }.forEach {
+                typeTx.getOwners(setOf()).filter { !loaded.contains(it) }.forEach {
                     load(it, isKey = false, isInherited = true)
                 }
                 ownerTypeProperties = properties

--- a/service/schema/ThingTypeState.kt
+++ b/service/schema/ThingTypeState.kt
@@ -48,7 +48,8 @@ import com.vaticle.typedb.studio.service.page.Navigable
 import com.vaticle.typedb.studio.service.page.Pageable
 import com.vaticle.typeql.lang.TypeQL
 import com.vaticle.typeql.lang.TypeQL.rel
-import com.vaticle.typeql.lang.TypeQL.`var`
+import com.vaticle.typeql.lang.TypeQL.cVar
+import com.vaticle.typeql.lang.common.TypeQLToken
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.atomic.AtomicBoolean
 import mu.KotlinLogging
@@ -214,7 +215,7 @@ sealed class ThingTypeState<TT : ThingType, TTS : ThingTypeState<TT, TTS>> const
                 val extendedType = inheritedType?.ownerTypesExplicit?.toSet()
                     ?.intersect(supertypes.toSet())?.firstOrNull()
                 val canBeUndefined = !tx.query().match(
-                    TypeQL.match(`var`("x").isa(typeTx.label.name()).has(attType.name, `var`("y")))
+                    TypeQL.match(cVar("x").isa(typeTx.label.name()).has(attType.name, cVar("y")))
                 ).findFirst().isPresent
                 properties.add(
                     AttributeTypeState.OwnedAttTypeProperties(
@@ -228,16 +229,16 @@ sealed class ThingTypeState<TT : ThingType, TTS : ThingTypeState<TT, TTS>> const
             val typeTx = conceptType.asRemote(tx)
             if (!loadedOwnedAttTypePropsAtomic.get()) {
                 loadedOwnedAttTypePropsAtomic.set(true)
-                typeTx.getOwnsExplicit(true).forEach {
+                typeTx.getOwnsExplicit(setOf(TypeQLToken.Annotation.KEY)).forEach {
                     load(tx = tx, typeTx = typeTx, attTypeConcept = it, isKey = true, isInherited = false)
                 }
-                typeTx.getOwnsExplicit(false).filter { !loaded.contains(it) }.forEach {
+                typeTx.getOwnsExplicit(setOf()).filter { !loaded.contains(it) }.forEach {
                     load(tx = tx, typeTx = typeTx, attTypeConcept = it, isKey = false, isInherited = false)
                 }
-                typeTx.getOwns(true).filter { !loaded.contains(it) }.forEach {
+                typeTx.getOwns(setOf(TypeQLToken.Annotation.KEY)).filter { !loaded.contains(it) }.forEach {
                     load(tx = tx, typeTx = typeTx, attTypeConcept = it, isKey = true, isInherited = true)
                 }
-                typeTx.getOwns(false).filter { !loaded.contains(it) }.forEach {
+                typeTx.getOwns(setOf()).filter { !loaded.contains(it) }.forEach {
                     load(tx = tx, typeTx = typeTx, attTypeConcept = it, isKey = false, isInherited = true)
                 }
                 ownedAttTypeProperties = properties
@@ -262,8 +263,8 @@ sealed class ThingTypeState<TT : ThingType, TTS : ThingTypeState<TT, TTS>> const
                     ?.intersect(supertypes.toSet())?.firstOrNull()
                 val canBeUndefined = !tx.query().match(
                     TypeQL.match(
-                        `var`("x").isa(typeTx.label.name()),
-                        rel(roleTypeConcept.label.name(), "x")
+                        cVar("x").isa(typeTx.label.name()),
+                        rel(roleTypeConcept.label.name(), cVar("x"))
                     )
                 ).findFirst().isPresent
                 properties.add(
@@ -339,10 +340,11 @@ sealed class ThingTypeState<TT : ThingType, TTS : ThingTypeState<TT, TTS>> const
     fun tryDefineOwnsAttributeType(
         attributeType: AttributeTypeState, overriddenType: AttributeTypeState?, isKey: Boolean, onSuccess: () -> Unit
     ) = schemaSrv.mayRunWriteTxAsync { tx ->
+        val annotationSet = if (isKey) setOf(TypeQLToken.Annotation.KEY) else emptySet()
         try {
             overriddenType?.let {
-                conceptType.asRemote(tx).setOwns(attributeType.conceptType, overriddenType.conceptType, isKey)
-            } ?: conceptType.asRemote(tx).setOwns(attributeType.conceptType, isKey)
+                conceptType.asRemote(tx).setOwns(attributeType.conceptType, overriddenType.conceptType, annotationSet)
+            } ?: conceptType.asRemote(tx).setOwns(attributeType.conceptType, annotationSet)
             loadOwnedAttributeTypes()
             onSuccess()
         } catch (e: Exception) {


### PR DESCRIPTION
## What is the goal of this PR?

We've bumped the java client that Studio uses to 2.18.

## What are the changes implemented in this PR?


# DRAFT
* relying on commit sha
* need some fixes wrt iskeyable being removed