### PR TITLE
Store cursor position when changing lines

### DIFF
--- a/framework/editor/InputTarget.kt
+++ b/framework/editor/InputTarget.kt
@@ -373,8 +373,7 @@ internal class InputTarget constructor(
     internal fun moveCursorUpByLine(isSelecting: Boolean = false) {
         if (cursor.row != 0) {
             val newRow = cursor.row - 1
-            var newCol = cursor.lastCol
-            newCol = newCol.coerceAtMost(content[newRow].length)
+            val newCol = cursor.lastCol.coerceAtMost(content[newRow].length)
             updateCursor(Cursor(newRow, newCol, lastCol = cursor.lastCol), isSelecting)
         }
     }
@@ -382,8 +381,7 @@ internal class InputTarget constructor(
     internal fun moveCursorDownByLine(isSelecting: Boolean = false) {
         if (cursor.row != content.size - 1) {
             val newRow = cursor.row + 1
-            var newCol = cursor.lastCol
-            newCol = newCol.coerceAtMost(content[newRow].length)
+            val newCol = cursor.lastCol.coerceAtMost(content[newRow].length)
             updateCursor(Cursor(newRow, newCol, lastCol = cursor.lastCol), isSelecting)
         }
     }

--- a/framework/editor/InputTarget.kt
+++ b/framework/editor/InputTarget.kt
@@ -66,7 +66,7 @@ internal class InputTarget constructor(
         }
     }
 
-    internal data class Cursor constructor(val row: Int, val col: Int) : Comparable<Cursor> {
+    internal data class Cursor constructor(val row: Int, val col: Int, val lastCol: Int = col) : Comparable<Cursor> {
 
         companion object {
             fun min(first: Cursor, second: Cursor): Cursor {
@@ -371,23 +371,21 @@ internal class InputTarget constructor(
     }
 
     internal fun moveCursorUpByLine(isSelecting: Boolean = false) {
-        var newRow = cursor.row - 1
-        var newCol = cursor.col
-        if (newRow < 0) {
-            newRow = 0
-            newCol = 0
-        } else newCol = newCol.coerceAtMost(content[newRow].length)
-        updateCursor(Cursor(newRow, newCol), isSelecting)
+        if (cursor.row != 0) {
+            val newRow = cursor.row - 1
+            var newCol = cursor.lastCol
+            newCol = newCol.coerceAtMost(content[newRow].length)
+            updateCursor(Cursor(newRow, newCol, lastCol = cursor.lastCol), isSelecting)
+        }
     }
 
     internal fun moveCursorDownByLine(isSelecting: Boolean = false) {
-        var newRow = cursor.row + 1
-        var newCol = cursor.col
-        if (newRow >= content.size) {
-            newRow = content.size - 1
-            newCol = content[newRow].length
-        } else newCol = newCol.coerceAtMost(content[newRow].length)
-        updateCursor(Cursor(newRow, newCol), isSelecting)
+        if (cursor.row != content.size - 1) {
+            val newRow = cursor.row + 1
+            var newCol = cursor.lastCol
+            newCol = newCol.coerceAtMost(content[newRow].length)
+            updateCursor(Cursor(newRow, newCol, lastCol = cursor.lastCol), isSelecting)
+        }
     }
 
     internal fun moveCursorUpByPage(isSelecting: Boolean = false) {


### PR DESCRIPTION
## What is the goal of this PR?

We store cursor positions when changing lines as described in https://github.com/vaticle/typedb-studio/issues/748. This is standard behaviour in other IDEs, such as IntelliJ IDEA and VSCode.

Before:

https://github.com/vaticle/typedb-studio/assets/51956016/9a4232b2-fb41-4276-9b48-76d741143329

After:

https://github.com/vaticle/typedb-studio/assets/51956016/0f311437-15f4-4a66-96d8-0005dedc6ad7



## What are the changes implemented in this PR?

We store an additional piece of data in `Cursor`, `lastCol`. This remembers the last position of the column, which we only forget upon the creation of a new cursor by a method other than moving up or down a line.

## Additional info
Closes https://github.com/vaticle/typedb-studio/issues/748
