### PR TITLE
Minimise queries made to refresh state after a schema write

### DIFF
--- a/module/type/TypeEditor.kt
+++ b/module/type/TypeEditor.kt
@@ -38,6 +38,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollbarAdapter
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -147,6 +148,7 @@ sealed class TypeEditor<T : ThingType, TS : ThingTypeState<T, TS>> constructor(
     override fun PrimaryContent() {
         val density = LocalDensity.current.density
         val bgColor = Theme.studio.backgroundDark
+        val onSchemaWrite: () -> Unit = { typeState.loadConstraintsAsync() }
         Box(Modifier.background(bgColor).focusRequester(focusReq).focusable()
             .onGloballyPositioned { width = toDP(it.size.width, density) }) {
             Box(Modifier.fillMaxSize().horizontalScroll(horScroller).verticalScroll(verScroller), Alignment.TopCenter) {
@@ -156,6 +158,10 @@ sealed class TypeEditor<T : ThingType, TS : ThingTypeState<T, TS>> constructor(
             Scrollbar.Horizontal(rememberScrollbarAdapter(horScroller), Modifier.align(Alignment.BottomCenter))
         }
         LaunchedEffect(focusReq) { focusReq.requestFocus() }
+        DisposableEffect(Unit) {
+            typeState.onSchemaWrite(onSchemaWrite)
+            onDispose { typeState.removeSchemaWriteCallback(onSchemaWrite) }
+        }
     }
 
     @Composable


### PR DESCRIPTION
## What is the goal of this PR?

We no longer reload the entire schema and all its connections on each schema write. Instead, we now reload the type hierarchy (for the Type Browser), and also, while there is a Type Editor open, it reloads all its data on a schema write.

This change drastically reduces the time taken to complete schema write operations.

## What are the changes implemented in this PR?

There was a bug (#723) where schema writes would freeze up Studio for a long time - specifically, it wouldn't be possible to commit the transaction or perform further queries. This was caused by overly aggressive refresh logic; we recursively loaded every edge for every type in the whole schema, using Studio's global schema write transaction. This rendered it unusable for anything until that refresh was done.

Now, we only reload the type hierarchy (necessary for Type Browser).

Also, the Schema service now broadcasts a "schema write" event whenever a schema write occurs. When opening a Type Editor, we subscribe to schema write events. On receiving an event, we reload the Type Editor. On closing the Type Editor, we unsubscribe from these events.

- closes #723 