### PR TITLE
Deploy studio for each OS + Arch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,13 +33,13 @@ executors:
 
   mac-arm64:
     macos:
-      xcode: "12.5.1"
+      xcode: "13.4.1"
     resource_class: macos.m1.medium.gen1
     working_directory: ~/typedb-studio
 
   mac-x86_64:
     macos:
-      xcode: "12.5.1"
+      xcode: "13.4.1"
     working_directory: ~/typedb-studio
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,24 +22,24 @@ orbs:
 executors:
   linux-arm64:
     machine:
-      image: ubuntu-2204:current
+      image: ubuntu-2004:current
       resource_class: arm.medium
     working_directory: ~/typedb-studio
 
   linux-x86_64:
     machine:
-      image: ubuntu-2204:current
+      image: ubuntu-2004:current
     working_directory: ~/typedb-studio
 
   mac-arm64:
     macos:
-      xcode: "14.2.0"
+      xcode: "12.5.1"
     resource_class: macos.m1.medium.gen1
     working_directory: ~/typedb-studio
 
   mac-x86_64:
     macos:
-      xcode: "14.2.0"
+      xcode: "12.5.1"
     working_directory: ~/typedb-studio
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,7 +185,7 @@ jobs:
           export DEPLOY_BREW_TOKEN=$REPO_GITHUB_TOKEN DEPLOY_BREW_USERNAME=$REPO_GITHUB_USERNAME DEPLOY_BREW_EMAIL=$REPO_GITHUB_EMAIL
           sha256sum ~/dist/typedb-studio-mac-arm64-$(cat VERSION).dmg | awk '{print $1}' > checksum-arm64
           sha256sum ~/dist/typedb-studio-mac-x86_64-$(cat VERSION).dmg | awk '{print $1}' > checksum-x86_64
-          bazel run --define version=$(cat VERSION) //:deploy-brew --@//:checksum-mac-arm64=:checksum-arm64 --@//:checksum-mac-x86_64=:checksum-x86_64 -- release
+          bazel run --define version=$(cat VERSION) //:deploy-brew --//:checksum-mac-arm64=:checksum-arm64 --//:checksum-mac-x86_64=:checksum-x86_64 -- release
 
   release-cleanup:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,8 +183,9 @@ jobs:
       - install-bazel-linux-x86_64
       - run: |
           export DEPLOY_BREW_TOKEN=$REPO_GITHUB_TOKEN DEPLOY_BREW_USERNAME=$REPO_GITHUB_USERNAME DEPLOY_BREW_EMAIL=$REPO_GITHUB_EMAIL
-          export DEPLOY_BREW_CHECKSUM=$(sha256sum ~/dist/typedb-studio-mac-$(cat VERSION).dmg | awk '{print $1}')
-          bazel run --define version=$(cat VERSION) //:deploy-brew -- release
+          sha256sum ~/dist/typedb-studio-mac-arm64-$(cat VERSION).dmg | awk '{print $1}' > checksum-arm64
+          sha256sum ~/dist/typedb-studio-mac-x86_64-$(cat VERSION).dmg | awk '{print $1}' > checksum-x86_64
+          bazel run --define version=$(cat VERSION) //:deploy-brew --@//:checksum-mac-arm64=:checksum-arm64 --@//:checksum-mac-x86_64=:checksum-x86_64 -- release
 
   release-cleanup:
     machine:

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -19,7 +19,7 @@ config:
   version-candidate: VERSION
   dependencies:
     dependencies: [ build ]
-    typedb-client-java: [ build, release ]
+    typedb-driver: [ build, release ]
 
 build:
   quality:

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -62,6 +62,9 @@ build:
         bazel test $(bazel query '//test/integration/... except kind(checkstyle_test, //test/integration/...)') --jobs=1 --spawn_strategy=local --test_output=errors
 
 release:
+  filter:
+    owner: vaticle
+    branch: master
   validation:
     validate-release-notes:
       image: vaticle-ubuntu-22.04

--- a/BUILD
+++ b/BUILD
@@ -201,26 +201,32 @@ assemble_targz(
     visibility = ["//:__pkg__"],
 )
 
-# We can't currently use this because the files to be deployed come in via
-# CircleCI's shared drive and are therefore not Bazel targets.
-#deploy_github(
-#    name = "deploy-github",
-#    organisation = deployment_github['github.organisation'],
-#    repository = deployment_github['github.repository'],
-#    title = "TypeDB Studio",
-#    title_append_version = True,
-#    release_description = "//:RELEASE_NOTES_LATEST.md",
-#    archive = ":assemble-platform",
-#    version_file = ":VERSION",
-#    draft = False
-#)
+genrule(
+    name = "invalid-checksum",
+    outs = [":invalid-checksum"],
+    srcs = [],
+    cmd = "echo > $@",
+)
+
+label_flag(
+    name = "checksum-mac-arm64",
+    build_setting_default = ":invalid-checksum",
+)
+
+label_flag(
+    name = "checksum-mac-x86_64",
+    build_setting_default = ":invalid-checksum",
+)
 
 deploy_brew(
     name = "deploy-brew",
     snapshot = deployment['brew.snapshot'],
     release = deployment['brew.release'],
     formula = "//config/brew:typedb-studio.rb",
-#    checksum = "//:checksum",
+    file_substitutions = {
+        "//:checksum-mac-arm64": "{sha256-arm64}",
+        "//:checksum-mac-x86_64": "{sha256-x86_64}",
+    },
     version_file = "//:VERSION",
     type = "cask",
 )

--- a/BUILD
+++ b/BUILD
@@ -203,7 +203,7 @@ assemble_targz(
 
 genrule(
     name = "invalid-checksum",
-    outs = [":invalid-checksum"],
+    outs = ["invalid-checksum.txt"],
     srcs = [],
     cmd = "echo > $@",
 )

--- a/BUILD
+++ b/BUILD
@@ -28,7 +28,7 @@ load("@io_bazel_rules_kotlin//kotlin/internal:toolchains.bzl", "define_kt_toolch
 load("@vaticle_bazel_distribution//platform/jvm:rules.bzl", "assemble_jvm_platform")
 load("@vaticle_typedb_common//test:rules.bzl", "native_typedb_artifact")
 load("@vaticle_bazel_distribution//artifact:rules.bzl", "artifact_extractor")
-load("@vaticle_dependencies//util/platform:constraints.bzl", "constraint_linux_arm64", "constraint_linux_x86_64",
+load("@vaticle_bazel_distribution//platform:constraints.bzl", "constraint_linux_arm64", "constraint_linux_x86_64",
      "constraint_mac_arm64", "constraint_mac_x86_64", "constraint_win_x86_64")
 
 package(default_visibility = ["//test/integration:__subpackages__"])
@@ -139,11 +139,11 @@ java_binary(
 java_deps(
     name = "assemble-deps",
     target = select({
-        "@vaticle_dependencies//util/platform:is_mac_arm64": ":studio-bin-mac-arm64",
-        "@vaticle_dependencies//util/platform:is_mac_x86_64": ":studio-bin-mac-x86_64",
-        "@vaticle_dependencies//util/platform:is_linux_arm64": ":studio-bin-linux-arm64",
-        "@vaticle_dependencies//util/platform:is_linux_x86_64": ":studio-bin-linux-x86_64",
-        "@vaticle_dependencies//util/platform:is_win_x86_64": ":studio-bin-windows-x86_64",
+        "@vaticle_bazel_distribution//platform:is_mac_arm64": ":studio-bin-mac-arm64",
+        "@vaticle_bazel_distribution//platform:is_mac_x86_64": ":studio-bin-mac-x86_64",
+        "@vaticle_bazel_distribution//platform:is_linux_arm64": ":studio-bin-linux-arm64",
+        "@vaticle_bazel_distribution//platform:is_linux_x86_64": ":studio-bin-linux-x86_64",
+        "@vaticle_bazel_distribution//platform:is_windows_x86_64": ":studio-bin-windows-x86_64",
         "//conditions:default": "INVALID",
     }),
     java_deps_root = "lib/",
@@ -158,11 +158,11 @@ assemble_jvm_platform(
     name = "assemble-platform",
     image_name = "TypeDB Studio",
     image_filename = "typedb-studio-" + select({
-        "@vaticle_dependencies//util/platform:is_mac_arm64": "mac-arm64",
-        "@vaticle_dependencies//util/platform:is_mac_x86_64": "mac-x86_64",
-        "@vaticle_dependencies//util/platform:is_linux_arm64": "linux-arm64",
-        "@vaticle_dependencies//util/platform:is_linux_x86_64": "linux-x86_64",
-        "@vaticle_dependencies//util/platform:is_win_x86_64": "windows-x86_64",
+        "@vaticle_bazel_distribution//platform:is_mac_arm64": "mac-arm64",
+        "@vaticle_bazel_distribution//platform:is_mac_x86_64": "mac-x86_64",
+        "@vaticle_bazel_distribution//platform:is_linux_arm64": "linux-arm64",
+        "@vaticle_bazel_distribution//platform:is_linux_x86_64": "linux-x86_64",
+        "@vaticle_bazel_distribution//platform:is_windows_x86_64": "windows-x86_64",
         "//conditions:default": "INVALID",
     }),
     description = "TypeDB's Integrated Development Environment",
@@ -171,9 +171,9 @@ assemble_jvm_platform(
     license_file = ":LICENSE",
     version_file = ":VERSION",
     icon = select({
-        "@vaticle_dependencies//util/platform:is_mac": "//resources/icons/vaticle:vaticle-bot-mac",
-        "@vaticle_dependencies//util/platform:is_linux": "//resources/icons/vaticle:vaticle-bot-linux",
-        "@vaticle_dependencies//util/platform:is_windows": "//resources/icons/vaticle:vaticle-bot-windows",
+        "@vaticle_bazel_distribution//platform:is_mac": "//resources/icons/vaticle:vaticle-bot-mac",
+        "@vaticle_bazel_distribution//platform:is_linux": "//resources/icons/vaticle:vaticle-bot-linux",
+        "@vaticle_bazel_distribution//platform:is_windows": "//resources/icons/vaticle:vaticle-bot-windows",
         "//conditions:default": "mac",
     }),
     java_deps = ":assemble-deps",
@@ -252,9 +252,13 @@ checkstyle_test(
 
 native_typedb_artifact(
     name = "native-typedb-artifact",
-    mac_artifact = "@vaticle_typedb_artifact_mac//file",
-    linux_artifact = "@vaticle_typedb_artifact_linux//file",
-    windows_artifact = "@vaticle_typedb_artifact_windows//file",
+    native_artifacts = {
+        "@vaticle_bazel_distribution//platform:is_linux_arm64": ["@vaticle_typedb_artifact_linux-arm64//file"],
+        "@vaticle_bazel_distribution//platform:is_linux_x86_64": ["@vaticle_typedb_artifact_linux-x86_64//file"],
+        "@vaticle_bazel_distribution//platform:is_mac_arm64": ["@vaticle_typedb_artifact_mac-arm64//file"],
+        "@vaticle_bazel_distribution//platform:is_mac_x86_64": ["@vaticle_typedb_artifact_mac-x86_64//file"],
+        "@vaticle_bazel_distribution//platform:is_windows_x86_64": ["@vaticle_typedb_artifact_windows-x86_64//file"],
+    },
     output = "typedb-server-native.tar.gz",
     visibility = ["//test/integration:__subpackages__"],
 )

--- a/config/brew/typedb-studio.rb
+++ b/config/brew/typedb-studio.rb
@@ -17,11 +17,19 @@
 
 cask 'typedb-studio' do
   version '{version}'
-  sha256 '{sha256}'
 
-  url "https://github.com/vaticle/typedb-studio/releases/download/{version}/typedb-studio-mac-{version}.dmg"
+  on_arm do
+    url "https://github.com/vaticle/typedb-studio/releases/download/{version}/typedb-studio-mac-arm64-{version}.dmg"
+    sha256 "{sha256-arm64}"
+  end
+
+  on_intel do
+    url "https://github.com/vaticle/typedb-studio/releases/download/{version}/typedb-studio-mac-x86_64-{version}.dmg"
+    sha256 "{sha256-x86_64}"
+  end
+
   name 'TypeDB Studio'
-  homepage 'https://vaticle.com'
+  homepage 'https://typedb.com'
 
   app "TypeDB Studio.app"
 

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -25,5 +25,5 @@ def vaticle_typedb_artifact():
         artifact_name = "typedb-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "23ab120977c42d8e793841d99adc649847456eb5",
+        commit = "029f44e1b39d1e418573c6e5805ea4b9e60f0869",
     )

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -25,5 +25,5 @@ def vaticle_typedb_artifact():
         artifact_name = "typedb-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "029f44e1b39d1e418573c6e5805ea4b9e60f0869",
+        commit = "f73907a60494228973cf3372b3eecb91770c90dd",
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -39,12 +39,8 @@ def vaticle_typedb_common():
     )
 
 def vaticle_typedb_driver():
-    native.local_repository(
+    git_repository(
         name = "vaticle_typedb_driver",
-        path = "/Users/dmitriiubskii/workspace/assembly-workspace/typedb-driver",
+        remote = "https://github.com/vaticle/typedb-driver",
+        commit = "c682ca915e0739e9413fa06156f368e8214ec169",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_client_java
     )
-#    git_repository(
-#        name = "vaticle_typedb_driver",
-#        remote = "https://github.com/vaticle/typedb-driver",
-#        commit = "9fbf317598c62ad168439d2b95a49edc5203d6a1",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_client_java
-#    )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -20,8 +20,8 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
-        remote = "https://github.com/dmitrii-ubskii/vaticle-dependencies",
-        commit = "54c29b9560883cdc7d4b37873930618f15995539",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        remote = "https://github.com/vaticle/dependencies",
+        commit = "fcc9a56b65e6ab69bbf0f1680affe38e12617ed6", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_force_graph():
@@ -34,8 +34,8 @@ def vaticle_force_graph():
 def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
-        remote = "https://github.com/dmitrii-ubskii/typedb-common",
-        commit = "21a29d0751910d40958eb3e52482f9b1f28d73ca",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        remote = "https://github.com/vaticle/typedb-common",
+        tag = "2.24.5",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_driver():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -35,12 +35,12 @@ def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
         remote = "https://github.com/vaticle/typedb-common",
-        tag = "2.24.5",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        tag = "2.24.10",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_driver():
     git_repository(
         name = "vaticle_typedb_driver",
         remote = "https://github.com/vaticle/typedb-driver",
-        commit = "c682ca915e0739e9413fa06156f368e8214ec169",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_client_java
+        tag = "2.24.11",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_client_java
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -20,8 +20,8 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
-        remote = "https://github.com/vaticle/dependencies",
-        commit = "56b33e3483731b043498c6f28fcb77cb97d41874", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        remote = "https://github.com/dmitrii-ubskii/vaticle-dependencies",
+        commit = "54c29b9560883cdc7d4b37873930618f15995539",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_force_graph():
@@ -34,13 +34,17 @@ def vaticle_force_graph():
 def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
-        remote = "https://github.com/vaticle/typedb-common",
-        tag = "2.24.2",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        remote = "https://github.com/dmitrii-ubskii/typedb-common",
+        commit = "21a29d0751910d40958eb3e52482f9b1f28d73ca",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_driver():
-    git_repository(
+    native.local_repository(
         name = "vaticle_typedb_driver",
-        remote = "https://github.com/vaticle/typedb-driver",
-        commit = "9fbf317598c62ad168439d2b95a49edc5203d6a1",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_client_java
+        path = "/Users/dmitriiubskii/workspace/assembly-workspace/typedb-driver",
     )
+#    git_repository(
+#        name = "vaticle_typedb_driver",
+#        remote = "https://github.com/vaticle/typedb-driver",
+#        commit = "9fbf317598c62ad168439d2b95a49edc5203d6a1",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_client_java
+#    )

--- a/framework/graph/GraphBuilder.kt
+++ b/framework/graph/GraphBuilder.kt
@@ -400,7 +400,7 @@ class GraphBuilder(
 
             private fun loadRoleplayerEdgesAndVertices() {
                 graphBuilder.apply {
-                    remoteThing?.asRelation()?.getPlayersByRoleType(transaction)?.entries?.forEach { (roleType, roleplayers) ->
+                    remoteThing?.asRelation()?.getPlayers(transaction)?.entries?.forEach { (roleType, roleplayers) ->
                         roleplayers.forEach { rp ->
                             val result = putVertexIfAbsent(rp.iid, rp, newThingVertices, allThingVertices) {
                                 Vertex.Thing.of(rp, graph)

--- a/framework/output/LogOutput.kt
+++ b/framework/output/LogOutput.kt
@@ -239,7 +239,7 @@ internal class LogOutput constructor(
 
     private fun printRolePlayers(relation: Relation): String {
         val rolePlayers = transactionState.transaction?.let {
-            relation.getPlayersByRoleType(it).flatMap { (role, players) ->
+            relation.getPlayers(it).flatMap { (role, players) ->
                 players.map { player -> role.label.name() + ": " + TypeQLToken.Constraint.IID + " " + player.iid }
             }.stream().collect(Collectors.joining(", "))
         } ?: " "

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -22,11 +22,11 @@ load("@vaticle_typedb_common//test:rules.bzl", "typedb_kt_test")
 package(default_visibility = ["//:__pkg__"])
 
 skiko_runtime_platform = select({
-    "@vaticle_dependencies//util/platform:is_linux_arm64": ["@maven//:org_jetbrains_skiko_skiko_awt_runtime_linux_arm64"],
-    "@vaticle_dependencies//util/platform:is_linux_x86_64": ["@maven//:org_jetbrains_skiko_skiko_awt_runtime_linux_x64"],
-    "@vaticle_dependencies//util/platform:is_mac_arm64": ["@maven//:org_jetbrains_skiko_skiko_awt_runtime_macos_arm64"],
-    "@vaticle_dependencies//util/platform:is_mac_x86_64": ["@maven//:org_jetbrains_skiko_skiko_awt_runtime_macos_x64"],
-    "@vaticle_dependencies//util/platform:is_windows": ["@maven//:org_jetbrains_skiko_skiko_awt_runtime_windows_x64"],
+    "@vaticle_bazel_distribution//platform:is_linux_arm64": ["@maven//:org_jetbrains_skiko_skiko_awt_runtime_linux_arm64"],
+    "@vaticle_bazel_distribution//platform:is_linux_x86_64": ["@maven//:org_jetbrains_skiko_skiko_awt_runtime_linux_x64"],
+    "@vaticle_bazel_distribution//platform:is_mac_arm64": ["@maven//:org_jetbrains_skiko_skiko_awt_runtime_macos_arm64"],
+    "@vaticle_bazel_distribution//platform:is_mac_x86_64": ["@maven//:org_jetbrains_skiko_skiko_awt_runtime_macos_x64"],
+    "@vaticle_bazel_distribution//platform:is_windows": ["@maven//:org_jetbrains_skiko_skiko_awt_runtime_windows_x64"],
     "//conditions:default": ["INVALID"],
 })
 
@@ -72,9 +72,13 @@ typedb_kt_test(
     name = "test-quickstart",
     srcs = ["QuickstartTest.kt"],
     data = ["//test/integration/data:sample-github-data-files"],
-    server_linux_artifact = "@vaticle_typedb_artifact_linux//file",
-    server_mac_artifact = "@vaticle_typedb_artifact_mac//file",
-    server_windows_artifact = "@vaticle_typedb_artifact_windows//file",
+    server_artifacts = {
+        "@vaticle_bazel_distribution//platform:is_linux_arm64": "@vaticle_typedb_artifact_linux-arm64//file",
+        "@vaticle_bazel_distribution//platform:is_linux_x86_64": "@vaticle_typedb_artifact_linux-x86_64//file",
+        "@vaticle_bazel_distribution//platform:is_mac_arm64": "@vaticle_typedb_artifact_mac-arm64//file",
+        "@vaticle_bazel_distribution//platform:is_mac_x86_64": "@vaticle_typedb_artifact_mac-x86_64//file",
+        "@vaticle_bazel_distribution//platform:is_windows_x86_64": "@vaticle_typedb_artifact_windows-x86_64//file",
+    },
     test_class = "com.vaticle.typedb.studio.test.integration.QuickstartTest",
     runtime_deps = skiko_runtime_platform,
     deps = compose_test_libraries,
@@ -84,9 +88,13 @@ typedb_kt_test(
     name = "test-queryrunner",
     srcs = ["QueryRunnerTest.kt"],
     data = ["//test/integration/data:sample-github-data-files"],
-    server_linux_artifact = "@vaticle_typedb_artifact_linux//file",
-    server_mac_artifact = "@vaticle_typedb_artifact_mac//file",
-    server_windows_artifact = "@vaticle_typedb_artifact_windows//file",
+    server_artifacts = {
+        "@vaticle_bazel_distribution//platform:is_linux_arm64": "@vaticle_typedb_artifact_linux-arm64//file",
+        "@vaticle_bazel_distribution//platform:is_linux_x86_64": "@vaticle_typedb_artifact_linux-x86_64//file",
+        "@vaticle_bazel_distribution//platform:is_mac_arm64": "@vaticle_typedb_artifact_mac-arm64//file",
+        "@vaticle_bazel_distribution//platform:is_mac_x86_64": "@vaticle_typedb_artifact_mac-x86_64//file",
+        "@vaticle_bazel_distribution//platform:is_windows_x86_64": "@vaticle_typedb_artifact_windows-x86_64//file",
+    },
     test_class = "com.vaticle.typedb.studio.test.integration.QueryRunnerTest",
     runtime_deps = skiko_runtime_platform,
     deps = compose_test_libraries + [
@@ -121,9 +129,13 @@ typedb_kt_test(
         "//test/integration/data:sample-file-structure-files",
         "//test/integration/data:sample-github-data-files",
     ],
-    server_linux_artifact = "@vaticle_typedb_artifact_linux//file",
-    server_mac_artifact = "@vaticle_typedb_artifact_mac//file",
-    server_windows_artifact = "@vaticle_typedb_artifact_windows//file",
+    server_artifacts = {
+        "@vaticle_bazel_distribution//platform:is_linux_arm64": "@vaticle_typedb_artifact_linux-arm64//file",
+        "@vaticle_bazel_distribution//platform:is_linux_x86_64": "@vaticle_typedb_artifact_linux-x86_64//file",
+        "@vaticle_bazel_distribution//platform:is_mac_arm64": "@vaticle_typedb_artifact_mac-arm64//file",
+        "@vaticle_bazel_distribution//platform:is_mac_x86_64": "@vaticle_typedb_artifact_mac-x86_64//file",
+        "@vaticle_bazel_distribution//platform:is_windows_x86_64": "@vaticle_typedb_artifact_windows-x86_64//file",
+    },
     test_class = "com.vaticle.typedb.studio.test.integration.TextEditorTest",
     runtime_deps = skiko_runtime_platform,
     deps = compose_test_libraries + [
@@ -151,9 +163,13 @@ typedb_kt_test(
         "//test/integration/data:sample-file-structure-files",
         "//test/integration/data:sample-github-data-files",
     ],
-    server_linux_artifact = "@vaticle_typedb_artifact_linux//file",
-    server_mac_artifact = "@vaticle_typedb_artifact_mac//file",
-    server_windows_artifact = "@vaticle_typedb_artifact_windows//file",
+    server_artifacts = {
+        "@vaticle_bazel_distribution//platform:is_linux_arm64": "@vaticle_typedb_artifact_linux-arm64//file",
+        "@vaticle_bazel_distribution//platform:is_linux_x86_64": "@vaticle_typedb_artifact_linux-x86_64//file",
+        "@vaticle_bazel_distribution//platform:is_mac_arm64": "@vaticle_typedb_artifact_mac-arm64//file",
+        "@vaticle_bazel_distribution//platform:is_mac_x86_64": "@vaticle_typedb_artifact_mac-x86_64//file",
+        "@vaticle_bazel_distribution//platform:is_windows_x86_64": "@vaticle_typedb_artifact_windows-x86_64//file",
+    },
     test_class = "com.vaticle.typedb.studio.test.integration.TypeBrowserTest",
     runtime_deps = skiko_runtime_platform,
     deps = compose_test_libraries + [

--- a/test/integration/common/BUILD
+++ b/test/integration/common/BUILD
@@ -21,11 +21,11 @@ load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 package(default_visibility = ["//test/integration:__pkg__"])
 
 skiko_runtime_platform = select({
-    "@vaticle_dependencies//util/platform:is_linux_arm64": ["@maven//:org_jetbrains_skiko_skiko_awt_runtime_linux_arm64"],
-    "@vaticle_dependencies//util/platform:is_linux_x86_64": ["@maven//:org_jetbrains_skiko_skiko_awt_runtime_linux_x64"],
-    "@vaticle_dependencies//util/platform:is_mac_arm64": ["@maven//:org_jetbrains_skiko_skiko_awt_runtime_macos_arm64"],
-    "@vaticle_dependencies//util/platform:is_mac_x86_64": ["@maven//:org_jetbrains_skiko_skiko_awt_runtime_macos_x64"],
-    "@vaticle_dependencies//util/platform:is_windows": ["@maven//:org_jetbrains_skiko_skiko_awt_runtime_windows_x64"],
+    "@vaticle_bazel_distribution//platform:is_linux_arm64": ["@maven//:org_jetbrains_skiko_skiko_awt_runtime_linux_arm64"],
+    "@vaticle_bazel_distribution//platform:is_linux_x86_64": ["@maven//:org_jetbrains_skiko_skiko_awt_runtime_linux_x64"],
+    "@vaticle_bazel_distribution//platform:is_mac_arm64": ["@maven//:org_jetbrains_skiko_skiko_awt_runtime_macos_arm64"],
+    "@vaticle_bazel_distribution//platform:is_mac_x86_64": ["@maven//:org_jetbrains_skiko_skiko_awt_runtime_macos_x64"],
+    "@vaticle_bazel_distribution//platform:is_windows": ["@maven//:org_jetbrains_skiko_skiko_awt_runtime_windows_x64"],
     "//conditions:default": ["INVALID"],
 })
 

--- a/test/integration/data/BUILD
+++ b/test/integration/data/BUILD
@@ -21,9 +21,9 @@ load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 package(default_visibility = ["//test/integration:__subpackages__"])
 
 skiko_runtime_platform = select({
-     "@vaticle_dependencies//util/platform:is_mac": ["@maven//:org_jetbrains_skiko_skiko_awt_runtime_macos_x64"],
-     "@vaticle_dependencies//util/platform:is_linux": ["@maven//:org_jetbrains_skiko_skiko_awt_runtime_linux_x64"],
-     "@vaticle_dependencies//util/platform:is_windows": ["@maven//:org_jetbrains_skiko_skiko_awt_runtime_windows_x64"],
+     "@vaticle_bazel_distribution//platform:is_mac": ["@maven//:org_jetbrains_skiko_skiko_awt_runtime_macos_x64"],
+     "@vaticle_bazel_distribution//platform:is_linux": ["@maven//:org_jetbrains_skiko_skiko_awt_runtime_linux_x64"],
+     "@vaticle_bazel_distribution//platform:is_windows": ["@maven//:org_jetbrains_skiko_skiko_awt_runtime_windows_x64"],
      "//conditions:default": ["INVALID"]})
 
 kt_jvm_library(


### PR DESCRIPTION
## What is the goal of this PR?

We deploy 5 separate distributions of TypeDB Studio, one per platform:

1. `linux-x86_64`
2. `linux-arm64`
3. `mac-x86_64`
4. `mac-arm64`
5. `windows-x86_64`

Please be aware that this means TypeDB Studio distributions are no longer portable between Intel and Mac variants of the same system - eg. from an Intel mac to an ARM mac. 

## What are the changes implemented in this PR?

* Add CPU architecture tags to assembly 
* Update homebrew formulae to handle arm and intel distribution