### PR TITLE
Windows build fixes

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -17,6 +17,6 @@
 
 try-import ./.bazel-remote-cache.rc
 
-build --incompatible_strict_action_env --javacopt='--release 11' --java_runtime_version=remotejdk_11
+build --incompatible_strict_action_env --javacopt='--release 11' --java_runtime_version=remotejdk_11 --enable_runfiles
 run --incompatible_strict_action_env --jvmopt='-ea' --java_runtime_version=remotejdk_11
 test --incompatible_strict_action_env --jvmopt='-ea' --java_runtime_version=remotejdk_11

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,13 +33,13 @@ executors:
 
   mac-arm64:
     macos:
-      xcode: "13.4.1"
+      xcode: "12.5.1"
     resource_class: macos.m1.medium.gen1
     working_directory: ~/typedb-studio
 
   mac-x86_64:
     macos:
-      xcode: "13.4.1"
+      xcode: "12.5.1"
     working_directory: ~/typedb-studio
 
 

--- a/.circleci/windows/build.bat
+++ b/.circleci/windows/build.bat
@@ -20,7 +20,7 @@ REM by Chocolatey in prepare.bat is accessible
 CALL refreshenv
 
 ECHO Building Windows application image...
-bazel build //:assemble-platform --compilation_mode=opt
+bazel --output_user_root=C:/b build //:assemble-platform --compilation_mode=opt
 IF %errorlevel% NEQ 0 EXIT /b %errorlevel%
 
 ECHO Extracting application image archive...

--- a/.circleci/windows/prepare.bat
+++ b/.circleci/windows/prepare.bat
@@ -16,6 +16,9 @@ REM You should have received a copy of the GNU Affero General Public License
 REM along with this program.  If not, see <https://www.gnu.org/licenses/>.
 REM
 
+REM shorten the workspace name so that we can avoid the long path restriction
+git apply .circleci\windows\short_workspace.patch
+
 REM uninstall Java 12 installed by CircleCI
 choco uninstall openjdk --limit-output --yes --no-progress
 

--- a/.circleci/windows/short_workspace.patch
+++ b/.circleci/windows/short_workspace.patch
@@ -1,0 +1,13 @@
+diff --git a/WORKSPACE b/WORKSPACE
+index 689b420f..5e3ecec8 100644
+--- a/WORKSPACE
++++ b/WORKSPACE
+@@ -15,7 +15,7 @@
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ 
+-workspace(name = "vaticle_typedb_studio")
++workspace(name = "v")
+ 
+ ################################
+ # Load @vaticle_dependencies #


### PR DESCRIPTION
## What is the goal of this PR?

We shorten bazel workspace path to work around the character limit on Windows, and enable runfiles linking for Rust compilation.