### PR TITLE
Ensure write transaction has been opened in integration test

### DIFF
--- a/test/integration/TextEditorTest.kt
+++ b/test/integration/TextEditorTest.kt
@@ -22,6 +22,7 @@
 package com.vaticle.typedb.studio.test.integration
 
 import com.vaticle.typedb.driver.api.TypeDBSession
+import com.vaticle.typedb.driver.api.TypeDBTransaction
 import com.vaticle.typedb.studio.framework.material.Icon
 import com.vaticle.typedb.studio.service.Service
 import com.vaticle.typedb.studio.service.common.util.Label
@@ -142,6 +143,10 @@ class TextEditorTest : IntegrationTest() {
 
                 clickText(composeRule, Label.SCHEMA.lowercase())
                 clickText(composeRule, Label.WRITE.lowercase())
+
+                waitUntilTrue(composeRule) {
+                    Service.driver.session.transaction.type == TypeDBTransaction.Type.WRITE
+                }
 
                 Service.project.current!!.directory.entries.find { it.name == SampleGitHubData.schemaFile }!!
                     .asFile().tryOpen()


### PR DESCRIPTION
## What is the goal of this PR?

We fix a spurious NPE that arises in the TextEditor integration test when a schema write is attempted before the write transaction is opened.