### PR TITLE
Fix unpacking driver runtime files into working directory

### DIFF
--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -42,12 +42,12 @@ def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
         remote = "https://github.com/vaticle/typedb-common",
-        tag = "2.24.14",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        tag = "2.24.15",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_driver():
     git_repository(
         name = "vaticle_typedb_driver",
         remote = "https://github.com/vaticle/typedb-driver",
-        tag = "2.24.14",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_client_java
+        tag = "2.24.15",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_client_java
     )


### PR DESCRIPTION
## What is the goal of this PR?

Due to a bug in the Java driver, we unpacked the driver dynamic library into the current working directory of Studio, rather than into a temporary directory. This was at best confusing, and at worst caused an unrecognized error in cases where the Studio was run from a read-only directory (such as `/Applications/` on mac OS.

We update to the driver version with the fix.