### PR TITLE
Update to driver with fixed error messages

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -27,6 +27,12 @@ vaticle_dependencies()
 load("@vaticle_dependencies//builder/bazel:deps.bzl", "bazel_toolchain")
 bazel_toolchain()
 
+# Load //builder/python
+load("@vaticle_dependencies//builder/python:deps.bzl", python_deps = "deps")
+python_deps()
+load("@rules_python//python:repositories.bzl", "py_repositories", "python_register_toolchains")
+py_repositories()
+
 # Load //builder/java
 load("@vaticle_dependencies//builder/java:deps.bzl", java_deps = "deps")
 java_deps()

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -28,7 +28,7 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "adda846178ed799aca001cc9dfd7934cd4f805a8", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "d75f30de7902892b1d45015aefd20f06048b0458", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_force_graph():
@@ -49,5 +49,5 @@ def vaticle_typedb_driver():
     git_repository(
         name = "vaticle_typedb_driver",
         remote = "https://github.com/dmitrii-ubskii/typedb-driver",
-        tag = "2.25.0",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_client_java
+        commit = "cd0cf031d109433f91d81b97a30e883dc82e358d",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_client_java
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -48,6 +48,6 @@ def vaticle_typedb_common():
 def vaticle_typedb_driver():
     git_repository(
         name = "vaticle_typedb_driver",
-        remote = "https://github.com/dmitrii-ubskii/typedb-driver",
-        commit = "cd0cf031d109433f91d81b97a30e883dc82e358d",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_client_java
+        remote = "https://github.com/vaticle/typedb-driver",
+        commit = "96be0f63c37e25622ad5d140de836dac09c65619",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_client_java
     )

--- a/framework/material/Form.kt
+++ b/framework/material/Form.kt
@@ -93,7 +93,10 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.rememberComponentRectPositionProvider
 import com.vaticle.typedb.studio.framework.common.Context.LocalTitleBarHeight
 import com.vaticle.typedb.studio.framework.common.Context.LocalWindowContext
 import com.vaticle.typedb.studio.framework.common.Util.getCursorRectSafely
@@ -439,6 +442,57 @@ object Form {
                 }
             },
         )
+    }
+
+    @OptIn(ExperimentalComposeUiApi::class)
+    @Composable
+    fun TextInputValidated(
+            value: String,
+            onValueChange: (String) -> Unit,
+            placeholder: String? = null,
+            singleLine: Boolean = true,
+            readOnly: Boolean = false,
+            enabled: Boolean = true,
+            isPassword: Boolean = false,
+            modifier: Modifier = Modifier,
+            fontColor: Color = Theme.studio.onSurface,
+            textStyle: TextStyle = Theme.typography.body1,
+            pointerHoverIcon: PointerIcon = PointerIconDefaults.Text,
+            onTextLayout: (TextLayoutResult) -> Unit = {},
+            shape: Shape? = ROUNDED_CORNER_SHAPE,
+            border: Border? = DEFAULT_BORDER,
+            trailingIcon: Icon? = null,
+            leadingIcon: Icon? = null,
+            invalidWarning: String,
+            validator: (String) -> Boolean = { true }
+    ) {
+        val borderColour = if (validator(value)) Theme.studio.border else Theme.studio.errorStroke
+        val mod = border?.let {
+            modifier.border(border.width, fadeable(borderColour, !enabled), border.shape)
+        } ?: modifier
+        val positionProvider = rememberComponentRectPositionProvider(
+                anchor = Alignment.TopStart,
+                alignment = Alignment.BottomEnd,
+                offset = DpOffset(0.dp, -(Form.FIELD_HEIGHT.value + Form.FIELD_SPACING.value).dp)
+        )
+        TextInput(
+                value, onValueChange, placeholder, singleLine, readOnly, enabled, isPassword, mod,
+                fontColor, textStyle, pointerHoverIcon, onTextLayout, shape, border, trailingIcon, leadingIcon,
+        )
+        if (!validator(value)) {
+            Popup(positionProvider) {
+                Box(
+                        Modifier.background(color = Theme.studio.errorBackground)
+                                .border(Form.BORDER_WIDTH, Theme.studio.errorStroke, RectangleShape)
+                ) {
+                    Column {
+                        Row(Modifier.padding(5.dp), Arrangement.SpaceBetween) {
+                            Text(value = invalidWarning)
+                        }
+                    }
+                }
+            }
+        }
     }
 
     @Composable

--- a/framework/material/Form.kt
+++ b/framework/material/Form.kt
@@ -473,7 +473,7 @@ object Form {
         val positionProvider = rememberComponentRectPositionProvider(
             anchor = Alignment.TopStart,
             alignment = Alignment.BottomEnd,
-            offset = DpOffset(0.dp, -(Form.FIELD_HEIGHT.value + Form.FIELD_SPACING.value).dp)
+            offset = DpOffset(0.dp, -(FIELD_HEIGHT.value + FIELD_SPACING.value).dp)
         )
         TextInput(
             value, onValueChange, placeholder, singleLine, readOnly, enabled, isPassword, mod,
@@ -483,7 +483,7 @@ object Form {
             Popup(positionProvider) {
                 Box(
                     Modifier.background(color = Theme.studio.errorBackground)
-                            .border(Form.BORDER_WIDTH, Theme.studio.errorStroke, RectangleShape)
+                            .border(BORDER_WIDTH, Theme.studio.errorStroke, RectangleShape)
                 ) {
                     Column {
                         Row(Modifier.padding(5.dp), Arrangement.SpaceBetween) {

--- a/framework/material/Form.kt
+++ b/framework/material/Form.kt
@@ -447,43 +447,43 @@ object Form {
     @OptIn(ExperimentalComposeUiApi::class)
     @Composable
     fun TextInputValidated(
-            value: String,
-            onValueChange: (String) -> Unit,
-            placeholder: String? = null,
-            singleLine: Boolean = true,
-            readOnly: Boolean = false,
-            enabled: Boolean = true,
-            isPassword: Boolean = false,
-            modifier: Modifier = Modifier,
-            fontColor: Color = Theme.studio.onSurface,
-            textStyle: TextStyle = Theme.typography.body1,
-            pointerHoverIcon: PointerIcon = PointerIconDefaults.Text,
-            onTextLayout: (TextLayoutResult) -> Unit = {},
-            shape: Shape? = ROUNDED_CORNER_SHAPE,
-            border: Border? = DEFAULT_BORDER,
-            trailingIcon: Icon? = null,
-            leadingIcon: Icon? = null,
-            invalidWarning: String,
-            validator: (String) -> Boolean = { true }
+        value: String,
+        onValueChange: (String) -> Unit,
+        placeholder: String? = null,
+        singleLine: Boolean = true,
+        readOnly: Boolean = false,
+        enabled: Boolean = true,
+        isPassword: Boolean = false,
+        modifier: Modifier = Modifier,
+        fontColor: Color = Theme.studio.onSurface,
+        textStyle: TextStyle = Theme.typography.body1,
+        pointerHoverIcon: PointerIcon = PointerIconDefaults.Text,
+        onTextLayout: (TextLayoutResult) -> Unit = {},
+        shape: Shape? = ROUNDED_CORNER_SHAPE,
+        border: Border? = DEFAULT_BORDER,
+        trailingIcon: Icon? = null,
+        leadingIcon: Icon? = null,
+        invalidWarning: String,
+        validator: (String) -> Boolean = { true }
     ) {
         val borderColour = if (validator(value)) Theme.studio.border else Theme.studio.errorStroke
         val mod = border?.let {
             modifier.border(border.width, fadeable(borderColour, !enabled), border.shape)
         } ?: modifier
         val positionProvider = rememberComponentRectPositionProvider(
-                anchor = Alignment.TopStart,
-                alignment = Alignment.BottomEnd,
-                offset = DpOffset(0.dp, -(Form.FIELD_HEIGHT.value + Form.FIELD_SPACING.value).dp)
+            anchor = Alignment.TopStart,
+            alignment = Alignment.BottomEnd,
+            offset = DpOffset(0.dp, -(Form.FIELD_HEIGHT.value + Form.FIELD_SPACING.value).dp)
         )
         TextInput(
-                value, onValueChange, placeholder, singleLine, readOnly, enabled, isPassword, mod,
-                fontColor, textStyle, pointerHoverIcon, onTextLayout, shape, border, trailingIcon, leadingIcon,
+            value, onValueChange, placeholder, singleLine, readOnly, enabled, isPassword, mod,
+            fontColor, textStyle, pointerHoverIcon, onTextLayout, shape, border, trailingIcon, leadingIcon,
         )
         if (!validator(value)) {
             Popup(positionProvider) {
                 Box(
-                        Modifier.background(color = Theme.studio.errorBackground)
-                                .border(Form.BORDER_WIDTH, Theme.studio.errorStroke, RectangleShape)
+                    Modifier.background(color = Theme.studio.errorBackground)
+                            .border(Form.BORDER_WIDTH, Theme.studio.errorStroke, RectangleShape)
                 ) {
                     Column {
                         Row(Modifier.padding(5.dp), Arrangement.SpaceBetween) {

--- a/module/connection/ServerDialog.kt
+++ b/module/connection/ServerDialog.kt
@@ -100,7 +100,7 @@ object ServerDialog {
                 }
                 TYPEDB_ENTERPRISE -> {
                     when {
-                        caCertificate.isBlank() -> Service.driver.tryConnectToTypeDBEnterpriseAsync(
+                        caCertificate.isBlank() || !tlsEnabled -> Service.driver.tryConnectToTypeDBEnterpriseAsync(
                             enterpriseAddresses.toSet(), username, password, tlsEnabled
                         ) {
                             Service.driver.connectServerDialog.close()

--- a/module/connection/ServerDialog.kt
+++ b/module/connection/ServerDialog.kt
@@ -198,7 +198,7 @@ object ServerDialog {
                 enabled = Service.driver.isDisconnected,
                 modifier = modifier,
                 invalidWarning = Label.ADDRESS_PORT_WARNING,
-                validator = { state.coreAddress.isNotBlank() && addressFormatIsValid(state.coreAddress) }
+                validator = { state.coreAddress.isBlank() || addressFormatIsValid(state.coreAddress) }
             )
         }
         LaunchedEffect(focusReq) { focusReq?.requestFocus() }
@@ -250,7 +250,7 @@ object ServerDialog {
                     onValueChange = { AddAddressForm.value = it },
                     modifier = Modifier.weight(1f).focusRequester(focusReq),
                     invalidWarning = Label.ADDRESS_PORT_WARNING,
-                    validator = { AddAddressForm.value.isNotBlank() && addressFormatIsValid(AddAddressForm.value) }
+                    validator = { AddAddressForm.value.isBlank() || addressFormatIsValid(AddAddressForm.value) }
                 )
                 RowSpacer()
                 TextButton(text = Label.ADD, enabled = AddAddressForm.isValid()) { AddAddressForm.submit() }

--- a/module/connection/ServerDialog.kt
+++ b/module/connection/ServerDialog.kt
@@ -50,6 +50,7 @@ import com.vaticle.typedb.studio.framework.material.Form.Submission
 import com.vaticle.typedb.studio.framework.material.Form.Text
 import com.vaticle.typedb.studio.framework.material.Form.TextButton
 import com.vaticle.typedb.studio.framework.material.Form.TextInput
+import com.vaticle.typedb.studio.framework.material.Form.TextInputValidated
 import com.vaticle.typedb.studio.framework.material.Icon
 import com.vaticle.typedb.studio.framework.material.SelectFileDialog
 import com.vaticle.typedb.studio.framework.material.SelectFileDialog.SelectorOptions
@@ -190,12 +191,14 @@ object ServerDialog {
         val focusReq = if (shouldFocus) remember { FocusRequester() } else null
         focusReq?.let { modifier = modifier.focusRequester(focusReq) }
         Field(label = Label.ADDRESS) {
-            TextInput(
+            TextInputValidated(
                 value = state.coreAddress,
                 placeholder = Label.DEFAULT_SERVER_ADDRESS,
                 onValueChange = { state.coreAddress = it },
                 enabled = Service.driver.isDisconnected,
-                modifier = modifier
+                modifier = modifier,
+                invalidWarning = Label.ADDRESS_PORT_WARNING,
+                validator = { state.coreAddress.isNotBlank() && addressFormatIsValid(state.coreAddress) }
             )
         }
         LaunchedEffect(focusReq) { focusReq?.requestFocus() }
@@ -241,11 +244,13 @@ object ServerDialog {
         val focusReq = remember { FocusRequester() }
         Submission(AddAddressForm, modifier = Modifier.height(Form.FIELD_HEIGHT), showButtons = false) {
             Row {
-                TextInput(
+                TextInputValidated(
                     value = AddAddressForm.value,
                     placeholder = Label.DEFAULT_SERVER_ADDRESS,
                     onValueChange = { AddAddressForm.value = it },
                     modifier = Modifier.weight(1f).focusRequester(focusReq),
+                    invalidWarning = Label.ADDRESS_PORT_WARNING,
+                    validator = { AddAddressForm.value.isNotBlank() && addressFormatIsValid(AddAddressForm.value) }
                 )
                 RowSpacer()
                 TextButton(text = Label.ADD, enabled = AddAddressForm.isValid()) { AddAddressForm.submit() }

--- a/module/connection/ServerDialog.kt
+++ b/module/connection/ServerDialog.kt
@@ -99,17 +99,14 @@ object ServerDialog {
                     }
                 }
                 TYPEDB_ENTERPRISE -> {
+                    val onSuccess = Service.driver.connectServerDialog::close
                     when {
                         caCertificate.isBlank() || !tlsEnabled -> Service.driver.tryConnectToTypeDBEnterpriseAsync(
-                            enterpriseAddresses.toSet(), username, password, tlsEnabled
-                        ) {
-                            Service.driver.connectServerDialog.close()
-                        }
+                            enterpriseAddresses.toSet(), username, password, tlsEnabled, onSuccess
+                        )
                         else -> Service.driver.tryConnectToTypeDBEnterpriseAsync(
-                            enterpriseAddresses.toSet(), username, password, caCertificate
-                        ) {
-                            Service.driver.connectServerDialog.close()
-                        }
+                            enterpriseAddresses.toSet(), username, password, caCertificate, onSuccess
+                        )
                     }
                 }
             }

--- a/module/connection/ServerDialog.kt
+++ b/module/connection/ServerDialog.kt
@@ -87,7 +87,7 @@ object ServerDialog {
 
         override fun cancel() = Service.driver.connectServerDialog.close()
         override fun isValid(): Boolean = when (server) {
-            TYPEDB -> coreAddress.isNotBlank()
+            TYPEDB -> coreAddress.isNotBlank() && addressFormatIsValid(coreAddress)
             TYPEDB_ENTERPRISE -> !(enterpriseAddresses.isEmpty() || username.isBlank() || password.isBlank())
         }
 
@@ -122,18 +122,18 @@ object ServerDialog {
     private object AddAddressForm : Form.State() {
         var value: String by mutableStateOf("")
         override fun cancel() = Service.driver.manageAddressesDialog.close()
-        override fun isValid() = value.isNotBlank() && validAddressFormat() && !state.enterpriseAddresses.contains(value)
+        override fun isValid() = value.isNotBlank() && addressFormatIsValid(value) && !state.enterpriseAddresses.contains(value)
 
         override fun submit() {
             assert(isValid())
             state.enterpriseAddresses.add(value)
             value = ""
         }
+    }
 
-        private fun validAddressFormat(): Boolean {
-            val addressParts = value.split(":")
-            return addressParts.size == 2 && addressParts[1].toIntOrNull()?.let { it in 1024..65535 } == true
-        }
+    private fun addressFormatIsValid(address: String): Boolean {
+        val addressParts = address.split(":")
+        return addressParts.size == 2 && addressParts[1].toIntOrNull()?.let { it in 1024..65535 } == true
     }
 
     @Composable

--- a/module/preference/PreferenceDialog.kt
+++ b/module/preference/PreferenceDialog.kt
@@ -292,9 +292,7 @@ object PreferenceDialog {
             return rootPreferenceGroup.isModified()
         }
 
-        override fun isValid(): Boolean {
-            return rootPreferenceGroup.isValid()
-        }
+        override fun isValid() = rootPreferenceGroup.isValid()
 
         override fun submit() {
             if (preferenceGroups.all { it.isValid() }) {

--- a/module/preference/PreferenceDialog.kt
+++ b/module/preference/PreferenceDialog.kt
@@ -129,45 +129,18 @@ object PreferenceDialog {
             @Composable
             override fun Display() {
                 Layout(caption) {
-                    val borderColour = if (this.isValid()) Theme.studio.border else Theme.studio.errorStroke
-                    val modifier = Modifier.border(1.dp, borderColour, RoundedCornerShape(Theme.ROUNDED_CORNER_RADIUS))
-                    val positionProvider = rememberComponentRectPositionProvider(
-                        anchor = Alignment.TopStart,
-                        alignment = Alignment.BottomEnd,
-                        offset = DpOffset(0.dp, -(Form.FIELD_HEIGHT.value + Form.FIELD_SPACING.value).dp)
-                    )
-                    Form.TextInput(
+                    Form.TextInputValidated(
                         value = value,
                         placeholder = placeholder,
-                        modifier = modifier,
-                        onValueChange = { value = it; modified = true }
+                        onValueChange = { value = it; modified = true },
+                        invalidWarning = invalidWarning,
+                        validator = validator,
                     )
-                    if (!this.isValid()) {
-                        InvalidPopup(invalidWarning, positionProvider)
-                    }
                 }
             }
 
             override fun isValid(): Boolean {
                 return validator(value)
-            }
-
-            @Composable
-            fun InvalidPopup(text: String, popupPositionProvider: PopupPositionProvider) {
-                Popup(
-                    popupPositionProvider
-                ) {
-                    Box(
-                        Modifier.background(color = Theme.studio.errorBackground)
-                            .border(Form.BORDER_WIDTH, Theme.studio.errorStroke, RectangleShape)
-                    ) {
-                        Column {
-                            Row(Modifier.padding(5.dp), Arrangement.SpaceBetween) {
-                                Text(value = text)
-                            }
-                        }
-                    }
-                }
             }
         }
 

--- a/service/common/util/Label.kt
+++ b/service/common/util/Label.kt
@@ -23,6 +23,7 @@ object Label {
     const val ADD = "Add"
     const val ADDRESS = "Address"
     const val ADDRESSES = "Addresses"
+    const val ADDRESS_PORT_WARNING = "Server address must include valid port number"
     const val ADVANCED = "Advanced"
     const val APPLY = "Apply"
     const val AS = "As"

--- a/service/common/util/Message.kt
+++ b/service/common/util/Message.kt
@@ -99,15 +99,9 @@ abstract class Message(codePrefix: String, codeNumber: Int, messagePrefix: Strin
             val TRANSACTION_CLOSED_IN_QUERY =
                 Connection(9, "Transaction was closed, due to an error in the query.")
             val TRANSACTION_ROLLBACK =
-                Connection(
-                    10,
-                    "Transaction has been rolled back to the opened snapshot, and all uncommitted writes have been deleted."
-                )
+                Connection(10, "Transaction has been rolled back to the opened snapshot, and all uncommitted writes have been deleted.")
             val TRANSACTION_COMMIT_SUCCESSFULLY =
-                Connection(
-                    11,
-                    "Transaction has been successfully committed and closed -- all writes have been persisted."
-                )
+                Connection(11, "Transaction has been successfully committed and closed -- all writes have been persisted.")
             val TRANSACTION_COMMIT_FAILED =
                 Connection(12, "Transaction failed to commit, due to:\n%s")
             val FAILED_TO_DELETE_DATABASE =


### PR DESCRIPTION
## What is the goal of this PR?

We update typedb-driver with error UX improvements.

## What are the changes implemented in this PR?

Drive-by: 
- fix connection dialog issue where if attempting to connect to TypeDB Enterprise with TLS disabled, but the root CA field (invisible to the user) having been populated, TLS would be forcibly enabled.
- disable the [Connect] button when attempting to connect to TypeDB Core Server with invalid address, and display a pop-up message