### PR TITLE
Update Enterprise error code prefix

### DIFF
--- a/service/connection/DriverState.kt
+++ b/service/connection/DriverState.kt
@@ -205,7 +205,7 @@ class DriverState(
         try {
             _driver?.databases()?.all()
         } catch (e: TypeDBDriverException) {
-            return e.toString().contains("CLS21")
+            return e.toString().contains("ENT21")
         }
         return false
     }

--- a/service/connection/DriverState.kt
+++ b/service/connection/DriverState.kt
@@ -205,7 +205,8 @@ class DriverState(
         try {
             _driver?.databases()?.all()
         } catch (e: TypeDBDriverException) {
-            return e.toString().contains("ENT21")
+            val errorString = e.toString()
+            return errorString.contains("ENT21") || errorString.contains("CLS21")
         }
         return false
     }


### PR DESCRIPTION
## Usage and product changes

* We've updated the enterprise error prefix in places where we detect certain errors.

## Implementation

* Update 'CLS' to 'ENT'

## Additional notes

We're aware that this is a hack, but currently these errors are not exposed in the API so it is not possible for us to detect certain errors cleanly.