### PR TITLE
Deploy artifacts to CloudSmith

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,12 +67,14 @@ commands:
         type: string
     steps:
       - run: |
+          export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+          export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
           # TODO Temporary measure. This exists for two reasons:
           # 1) platform-jvm assembly rules currently requires the version to be specified in a version_file
           # 2) jpackage does not support 0 as a major version
           # This writes VERSION-SHA1 into the VERSION file to be used by the assembly rule.
           echo $(cat VERSION)-$CIRCLE_SHA1 > VERSION
-          bazel run //:deploy-mac-<<parameters.target-arch>>-dmg --compilation_mode=opt --spawn_strategy=local -- snapshot
+          bazel run --define version=$(cat VERSION) //:deploy-mac-<<parameters.target-arch>>-dmg --compilation_mode=opt --spawn_strategy=local -- snapshot
 
   deploy-mac-release:
     parameters:
@@ -80,7 +82,7 @@ commands:
         type: string
     steps:
       - run: |
-          bazel run //:deploy-mac-<<parameters.target-arch>>-dmg --compilation_mode=opt \
+          bazel run --define version=$(cat VERSION) //:deploy-mac-<<parameters.target-arch>>-dmg --compilation_mode=opt \
               --define APPLE_CODE_SIGN=yes \
               --define APPLE_ID=$APPLE_ID \
               --define APPLE_ID_PASSWORD=$APPLE_ID_PASSWORD \
@@ -124,7 +126,7 @@ jobs:
           # 2) jpackage does not support 0 as a major version
           # This writes VERSION-SHA1 into the VERSION file to be used by the assembly rule.
           echo $(cat VERSION)-$CIRCLE_SHA1 > VERSION
-          bazel run //:deploy-linux-arm64-targz --compilation_mode=opt -- snapshot
+          bazel run --define version=$(cat VERSION) //:deploy-linux-arm64-targz --compilation_mode=opt -- snapshot
 
   deploy-linux-x86_64-snapshot:
     executor: linux-x86_64
@@ -139,7 +141,7 @@ jobs:
           # 2) jpackage does not support 0 as a major version
           # This writes VERSION-SHA1 into the VERSION file to be used by the assembly rule.
           echo $(cat VERSION)-$CIRCLE_SHA1 > VERSION
-          bazel run //:deploy-linux-x86_64-targz --compilation_mode=opt -- snapshot
+          bazel run --define version=$(cat VERSION) //:deploy-linux-x86_64-targz --compilation_mode=opt -- snapshot
 
   deploy-windows-x86_64-snapshot:
     executor:
@@ -192,16 +194,16 @@ jobs:
     steps:
       - checkout
       - install-bazel-linux-arm64
-      - run: bazel run //:deploy-linux-arm64-deb --compilation_mode=opt -- release
-      - run: bazel run //:deploy-linux-arm64-targz --compilation_mode=opt -- release
+      - run: bazel run --define version=$(cat VERSION) //:deploy-linux-arm64-deb --compilation_mode=opt -- release
+      - run: bazel run --define version=$(cat VERSION) //:deploy-linux-arm64-targz --compilation_mode=opt -- release
 
   deploy-linux-x86_64-release:
     executor: linux-x86_64
     steps:
       - checkout
       - install-bazel-linux-x86_64
-      - run: bazel run //:deploy-linux-x86_64-deb --compilation_mode=opt -- release
-      - run: bazel run //:deploy-linux-x86_64-targz --compilation_mode=opt -- release
+      - run: bazel run --define version=$(cat VERSION) //:deploy-linux-x86_64-deb --compilation_mode=opt -- release
+      - run: bazel run --define version=$(cat VERSION) //:deploy-linux-x86_64-targz --compilation_mode=opt -- release
 
   deploy-windows-x86_64-release:
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ commands:
           # 2) jpackage does not support 0 as a major version
           # This writes VERSION-SHA1 into the VERSION file to be used by the assembly rule.
           echo $(cat VERSION)-$CIRCLE_SHA1 > VERSION
-          bazel run --define version=$(cat VERSION) //:deploy-mac-<<parameters.target-arch>>-dmg --compilation_mode=opt --spawn_strategy=local -- snapshot
+          bazel run //:deploy-mac-<<parameters.target-arch>>-dmg --compilation_mode=opt --spawn_strategy=local -- snapshot
 
   deploy-mac-release:
     parameters:
@@ -82,7 +82,7 @@ commands:
         type: string
     steps:
       - run: |
-          bazel run --define version=$(cat VERSION) //:deploy-mac-<<parameters.target-arch>>-dmg --compilation_mode=opt \
+          bazel run //:deploy-mac-<<parameters.target-arch>>-dmg --compilation_mode=opt \
               --define APPLE_CODE_SIGN=yes \
               --define APPLE_ID=$APPLE_ID \
               --define APPLE_ID_PASSWORD=$APPLE_ID_PASSWORD \
@@ -126,7 +126,7 @@ jobs:
           # 2) jpackage does not support 0 as a major version
           # This writes VERSION-SHA1 into the VERSION file to be used by the assembly rule.
           echo $(cat VERSION)-$CIRCLE_SHA1 > VERSION
-          bazel run --define version=$(cat VERSION) //:deploy-linux-arm64-targz --compilation_mode=opt -- snapshot
+          bazel run //:deploy-linux-arm64-targz --compilation_mode=opt -- snapshot
 
   deploy-linux-x86_64-snapshot:
     executor: linux-x86_64
@@ -141,7 +141,7 @@ jobs:
           # 2) jpackage does not support 0 as a major version
           # This writes VERSION-SHA1 into the VERSION file to be used by the assembly rule.
           echo $(cat VERSION)-$CIRCLE_SHA1 > VERSION
-          bazel run --define version=$(cat VERSION) //:deploy-linux-x86_64-targz --compilation_mode=opt -- snapshot
+          bazel run //:deploy-linux-x86_64-targz --compilation_mode=opt -- snapshot
 
   deploy-windows-x86_64-snapshot:
     executor:
@@ -194,16 +194,16 @@ jobs:
     steps:
       - checkout
       - install-bazel-linux-arm64
-      - run: bazel run --define version=$(cat VERSION) //:deploy-linux-arm64-deb --compilation_mode=opt -- release
-      - run: bazel run --define version=$(cat VERSION) //:deploy-linux-arm64-targz --compilation_mode=opt -- release
+      - run: bazel run //:deploy-linux-arm64-deb --compilation_mode=opt -- release
+      - run: bazel run //:deploy-linux-arm64-targz --compilation_mode=opt -- release
 
   deploy-linux-x86_64-release:
     executor: linux-x86_64
     steps:
       - checkout
       - install-bazel-linux-x86_64
-      - run: bazel run --define version=$(cat VERSION) //:deploy-linux-x86_64-deb --compilation_mode=opt -- release
-      - run: bazel run --define version=$(cat VERSION) //:deploy-linux-x86_64-targz --compilation_mode=opt -- release
+      - run: bazel run //:deploy-linux-x86_64-deb --compilation_mode=opt -- release
+      - run: bazel run //:deploy-linux-x86_64-targz --compilation_mode=opt -- release
 
   deploy-windows-x86_64-release:
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -259,11 +259,26 @@ jobs:
 workflows:
   snapshot:
     jobs:
-      - deploy-linux-arm64-snapshot
-      - deploy-linux-x86_64-snapshot
-      - deploy-mac-arm64-snapshot
-      - deploy-mac-x86_64-snapshot
-      - deploy-windows-x86_64-snapshot
+      - deploy-linux-arm64-snapshot:
+          filters:
+            branches:
+              only: [master, development]
+      - deploy-linux-x86_64-snapshot:
+          filters:
+            branches:
+              only: [master, development]
+      - deploy-mac-arm64-snapshot:
+          filters:
+            branches:
+              only: [master, development]
+      - deploy-mac-x86_64-snapshot:
+          filters:
+            branches:
+              only: [master, development]
+      - deploy-windows-x86_64-snapshot:
+          filters:
+            branches:
+              only: [master, development]
   release:
     jobs:
       - deploy-linux-arm64-release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,9 +138,9 @@ jobs:
       - run:
           name: "Publish Draft Release on GitHub"
           command: |
-            wget https://github.com/tcnksm/ghr/releases/download/v0.12.1/ghr_v0.12.1_linux_amd64.tar.gz
-            tar -xf ghr_v0.12.1_linux_amd64.tar.gz
-            ghr_v0.12.1_linux_amd64/ghr -t ${REPO_GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} \
+            wget https://github.com/tcnksm/ghr/releases/download/v0.16.2/ghr_v0.16.2_linux_amd64.tar.gz
+            tar -xf ghr_v0.16.2_linux_amd64.tar.gz
+            ghr_v0.16.2_linux_amd64/ghr -t ${REPO_GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} \
               -r ${CIRCLE_PROJECT_REPONAME} -n "TypeDB Studio $(cat VERSION)" -b "$(cat ./RELEASE_NOTES_LATEST.md)" \
               -c ${CIRCLE_SHA1} -delete $(cat VERSION)
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,32 @@ commands:
               --define APPLE_CODE_SIGNING_CERT_PASSWORD=$APPLE_CODE_SIGNING_CERT_PASSWORD \
               --spawn_strategy=local -- release
 
+  deploy-linux-snapshot:
+    parameters:
+      target-arch:
+        type: string
+    steps:
+      - run: |
+          export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+          export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
+          # TODO Temporary measure. This exists for two reasons:
+          # 1) platform-jvm assembly rules currently requires the version to be specified in a version_file
+          # 2) jpackage does not support 0 as a major version
+          # This writes VERSION-SHA1 into the VERSION file to be used by the assembly rule.
+          echo $(cat VERSION)-$CIRCLE_SHA1 > VERSION
+          bazel run //:deploy-linux-<<parameters.target-arch>>-targz --compilation_mode=opt -- snapshot
+
+  deploy-linux-release:
+    parameters:
+      target-arch:
+        type: string
+    steps:
+      - run: |
+          export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+          export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
+          bazel run //:deploy-linux-<<parameters.target-arch>>-deb --compilation_mode=opt -- release
+          bazel run //:deploy-linux-<<parameters.target-arch>>-targz --compilation_mode=opt -- release
+
 jobs:
   deploy-mac-arm64-snapshot:
     executor: mac-arm64
@@ -114,30 +140,16 @@ jobs:
     steps:
       - checkout
       - install-bazel-linux-arm64
-      - run: |
-          export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
-          export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
-          # TODO Temporary measure. This exists for two reasons:
-          # 1) platform-jvm assembly rules currently requires the version to be specified in a version_file
-          # 2) jpackage does not support 0 as a major version
-          # This writes VERSION-SHA1 into the VERSION file to be used by the assembly rule.
-          echo $(cat VERSION)-$CIRCLE_SHA1 > VERSION
-          bazel run //:deploy-linux-arm64-targz --compilation_mode=opt -- snapshot
+      - deploy-linux-snapshot:
+          target-arch: arm64
 
   deploy-linux-x86_64-snapshot:
     executor: linux-x86_64
     steps:
       - checkout
       - install-bazel-linux-x86_64
-      - run: |
-          export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
-          export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
-          # TODO Temporary measure. This exists for two reasons:
-          # 1) platform-jvm assembly rules currently requires the version to be specified in a version_file
-          # 2) jpackage does not support 0 as a major version
-          # This writes VERSION-SHA1 into the VERSION file to be used by the assembly rule.
-          echo $(cat VERSION)-$CIRCLE_SHA1 > VERSION
-          bazel run //:deploy-linux-x86_64-targz --compilation_mode=opt -- snapshot
+      - deploy-linux-snapshot:
+          target-arch: x86_64
 
   deploy-windows-x86_64-snapshot:
     executor:
@@ -190,22 +202,16 @@ jobs:
     steps:
       - checkout
       - install-bazel-linux-arm64
-      - run: |
-          export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
-          export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
-          bazel run //:deploy-linux-arm64-deb --compilation_mode=opt -- release
-          bazel run //:deploy-linux-arm64-targz --compilation_mode=opt -- release
+      - deploy-linux-release:
+          target-arch: arm64
 
   deploy-linux-x86_64-release:
     executor: linux-x86_64
     steps:
       - checkout
       - install-bazel-linux-x86_64
-      - run: |
-          export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
-          export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
-          bazel run //:deploy-linux-x86_64-deb --compilation_mode=opt -- release
-          bazel run //:deploy-linux-x86_64-targz --compilation_mode=opt -- release
+      - deploy-linux-release:
+          target-arch: x86_64
 
   deploy-windows-x86_64-release:
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -316,10 +316,12 @@ workflows:
             branches:
               only: release
           requires:
-            - deploy-github
+            - deploy-mac-arm64-release
+            - deploy-mac-x86_64-release
       - release-cleanup:
           filters:
             branches:
               only: release
           requires:
+            - deploy-github
             - deploy-brew

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,8 +95,8 @@ jobs:
       - checkout
       - install-bazel-mac
       - run: |
-          export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
-          export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
+          export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+          export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
           bazel run @vaticle_dependencies//distribution/artifact:create-netrc
       - deploy-mac-snapshot:
           target-arch: arm64
@@ -107,8 +107,8 @@ jobs:
       - checkout
       - install-bazel-mac
       - run: |
-          export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
-          export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
+          export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+          export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
           bazel run @vaticle_dependencies//distribution/artifact:create-netrc
       - deploy-mac-snapshot:
           target-arch: x86_64
@@ -155,8 +155,8 @@ jobs:
       - checkout
       - install-bazel-mac
       - run: |
-          export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
-          export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
+          export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+          export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
           bazel run @vaticle_dependencies//distribution/artifact:create-netrc
       - deploy-mac-release:
           target-arch: arm64
@@ -173,8 +173,8 @@ jobs:
       - checkout
       - install-bazel-mac
       - run: |
-          export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
-          export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
+          export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+          export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
           bazel run @vaticle_dependencies//distribution/artifact:create-netrc
       - deploy-mac-release:
           target-arch: x86_64

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,6 +82,8 @@ commands:
         type: string
     steps:
       - run: |
+          export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+          export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
           bazel run //:deploy-mac-<<parameters.target-arch>>-dmg --compilation_mode=opt \
               --define APPLE_CODE_SIGN=yes \
               --define APPLE_ID=$APPLE_ID \
@@ -96,9 +98,6 @@ jobs:
     steps:
       - checkout
       - install-bazel-mac
-      - run: |
-          export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
-          export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
       - deploy-mac-snapshot:
           target-arch: arm64
 
@@ -107,9 +106,6 @@ jobs:
     steps:
       - checkout
       - install-bazel-mac
-      - run: |
-          export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
-          export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
       - deploy-mac-snapshot:
           target-arch: x86_64
 
@@ -194,16 +190,22 @@ jobs:
     steps:
       - checkout
       - install-bazel-linux-arm64
-      - run: bazel run //:deploy-linux-arm64-deb --compilation_mode=opt -- release
-      - run: bazel run //:deploy-linux-arm64-targz --compilation_mode=opt -- release
+      - run: |
+          export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+          export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
+          bazel run //:deploy-linux-arm64-deb --compilation_mode=opt -- release
+          bazel run //:deploy-linux-arm64-targz --compilation_mode=opt -- release
 
   deploy-linux-x86_64-release:
     executor: linux-x86_64
     steps:
       - checkout
       - install-bazel-linux-x86_64
-      - run: bazel run //:deploy-linux-x86_64-deb --compilation_mode=opt -- release
-      - run: bazel run //:deploy-linux-x86_64-targz --compilation_mode=opt -- release
+      - run: |
+          export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+          export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
+          bazel run //:deploy-linux-x86_64-deb --compilation_mode=opt -- release
+          bazel run //:deploy-linux-x86_64-targz --compilation_mode=opt -- release
 
   deploy-windows-x86_64-release:
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,26 +230,11 @@ jobs:
 workflows:
   snapshot:
     jobs:
-      - deploy-linux-arm64-snapshot:
-          filters:
-            branches:
-              only: [master, development]
-      - deploy-linux-x86_64-snapshot:
-          filters:
-            branches:
-              only: [master, development]
-      - deploy-mac-arm64-snapshot:
-          filters:
-            branches:
-              only: [master, development]
-      - deploy-mac-x86_64-snapshot:
-          filters:
-            branches:
-              only: [master, development]
-      - deploy-windows-x86_64-snapshot:
-          filters:
-            branches:
-              only: [master, development]
+      - deploy-linux-arm64-snapshot
+      - deploy-linux-x86_64-snapshot
+      - deploy-mac-arm64-snapshot
+      - deploy-mac-x86_64-snapshot
+      - deploy-windows-x86_64-snapshot
   release:
     jobs:
       - deploy-linux-arm64-release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,13 +22,13 @@ orbs:
 executors:
   linux-arm64:
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2004:2023.10.1
       resource_class: arm.medium
     working_directory: ~/typedb-studio
 
   linux-x86_64:
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2004:2023.10.1
     working_directory: ~/typedb-studio
 
   mac-arm64:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,17 +109,6 @@ jobs:
       - install-bazel-linux-arm64
       - run: bazel build //:assemble-platform --compilation_mode=opt
       - run: bazel build //:assemble-linux-targz --compilation_mode=opt
-      - run: |
-          mkdir -p ~/src
-          mkdir -p ~/dist
-          cp bazel-bin/typedb-studio-linux.tar.gz ~/dist/typedb-studio-linux-arm64-$(cat VERSION).tar.gz
-          cp bazel-bin/assemble-platform.zip ~/src
-          cd ~/dist
-          jar xf ~/src/assemble-platform.zip
-      - persist_to_workspace:
-          root: ~/dist
-          paths:
-            - ./*
 
   build-linux-x86_64:
     executor: linux-x86_64
@@ -128,17 +117,6 @@ jobs:
       - install-bazel-linux-x86_64
       - run: bazel build //:assemble-platform --compilation_mode=opt
       - run: bazel build //:assemble-linux-targz --compilation_mode=opt
-      - run: |
-          mkdir -p ~/src
-          mkdir -p ~/dist
-          cp bazel-bin/typedb-studio-linux.tar.gz ~/dist/typedb-studio-linux-x86_64-$(cat VERSION).tar.gz
-          cp bazel-bin/assemble-platform.zip ~/src
-          cd ~/dist
-          jar xf ~/src/assemble-platform.zip
-      - persist_to_workspace:
-          root: ~/dist
-          paths:
-            - ./*
 
   build-windows-x86_64:
     executor:
@@ -149,16 +127,10 @@ jobs:
       - checkout
       - run: .circleci\windows\prepare.bat
       - run: .circleci\windows\build.bat
-      - persist_to_workspace:
-          root: dist
-          paths:
-            - ./*
 
   deploy-github:
     executor: linux-x86_64
     steps:
-      - attach_workspace:
-          at: ~/dist
       - checkout
       - run:
           name: "Publish Draft Release on GitHub"
@@ -167,7 +139,7 @@ jobs:
             tar -xf ghr_v0.12.1_linux_amd64.tar.gz
             ghr_v0.12.1_linux_amd64/ghr -t ${REPO_GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} \
               -r ${CIRCLE_PROJECT_REPONAME} -n "TypeDB Studio $(cat VERSION)" -b "$(cat ./RELEASE_NOTES_LATEST.md)" \
-              -c ${CIRCLE_SHA1} -delete $(cat VERSION) ~/dist/
+              -c ${CIRCLE_SHA1} -delete $(cat VERSION)
 
   deploy-brew:
     executor: linux-x86_64

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,12 +61,15 @@ commands:
     steps:
       - run: brew install bazelisk
 
-  assemble-mac:
+  deploy-mac:
+    parameters:
+      target-arch:
+        type: string
     steps:
-      - run: bazel build //:assemble-platform --compilation_mode=opt --define APPLE_CODE_SIGN=yes --define APPLE_ID=$APPLE_ID --define APPLE_ID_PASSWORD=$APPLE_ID_PASSWORD --define APPLE_TEAM_ID=$APPLE_TEAM_ID --define APPLE_CODE_SIGNING_CERT_PASSWORD=$APPLE_CODE_SIGNING_CERT_PASSWORD --spawn_strategy=local
+      - run: bazel run //:deploy-mac-<<parameters.target-arch>>-dmg --compilation_mode=opt --define APPLE_CODE_SIGN=yes --define APPLE_ID=$APPLE_ID --define APPLE_ID_PASSWORD=$APPLE_ID_PASSWORD --define APPLE_TEAM_ID=$APPLE_TEAM_ID --define APPLE_CODE_SIGNING_CERT_PASSWORD=$APPLE_CODE_SIGNING_CERT_PASSWORD --spawn_strategy=local
 
 jobs:
-  build-mac-arm64:
+  deploy-mac-arm64:
     executor: mac-arm64
     steps:
       - checkout
@@ -75,16 +78,16 @@ jobs:
           export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
           export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
           bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-      - assemble-mac
+      - deploy-mac:
+          target-arch: arm64
       - run: |
-          mkdir -p ~/src && cp bazel-bin/assemble-platform.zip ~/src
-          mkdir -p ~/dist && cd ~/dist && jar xf ~/src/assemble-platform.zip
+          mkdir -p ~/dist && cp bazel-bin/typedb-studio-mac-arm64-*.dmg ~/dist
       - persist_to_workspace:
           root: ~/dist
           paths:
             - ./*
 
-  build-mac-x86_64:
+  deploy-mac-x86_64:
     executor: mac-x86_64
     steps:
       - checkout
@@ -93,32 +96,32 @@ jobs:
           export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
           export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
           bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-      - assemble-mac
+      - deploy-mac:
+          target-arch: x86_64
       - run: |
-          mkdir -p ~/src && cp bazel-bin/assemble-platform.zip ~/src
-          mkdir -p ~/dist && cd ~/dist && jar xf ~/src/assemble-platform.zip
+          mkdir -p ~/dist && cp bazel-bin/typedb-studio-mac-x86_64-*.dmg ~/dist
       - persist_to_workspace:
           root: ~/dist
           paths:
             - ./*
 
-  build-linux-arm64:
+  deploy-linux-arm64:
     executor: linux-arm64
     steps:
       - checkout
       - install-bazel-linux-arm64
-      - run: bazel build //:assemble-platform --compilation_mode=opt
-      - run: bazel build //:assemble-linux-targz --compilation_mode=opt
+      - run: bazel run //:deploy-linux-arm64-deb --compilation_mode=opt
+      - run: bazel run //:deploy-linux-arm64-targz --compilation_mode=opt
 
-  build-linux-x86_64:
+  deploy-linux-x86_64:
     executor: linux-x86_64
     steps:
       - checkout
       - install-bazel-linux-x86_64
-      - run: bazel build //:assemble-platform --compilation_mode=opt
-      - run: bazel build //:assemble-linux-targz --compilation_mode=opt
+      - run: bazel run //:deploy-linux-x86_64-deb --compilation_mode=opt
+      - run: bazel run //:deploy-linux-x86_64-targz --compilation_mode=opt
 
-  build-windows-x86_64:
+  deploy-windows-x86_64:
     executor:
       name: win/default
       shell: cmd.exe
@@ -126,7 +129,7 @@ jobs:
     steps:
       - checkout
       - run: .circleci\windows\prepare.bat
-      - run: .circleci\windows\build.bat
+      - run: .circleci\windows\deploy.bat
 
   deploy-github:
     executor: linux-x86_64
@@ -164,23 +167,23 @@ jobs:
 workflows:
   release:
     jobs:
-      - build-linux-arm64:
+      - deploy-linux-arm64:
           filters:
             branches:
               only: release
-      - build-linux-x86_64:
+      - deploy-linux-x86_64:
           filters:
             branches:
               only: release
-      - build-mac-arm64:
+      - deploy-mac-arm64:
           filters:
             branches:
               only: release
-      - build-mac-x86_64:
+      - deploy-mac-x86_64:
           filters:
             branches:
               only: release
-      - build-windows-x86_64:
+      - deploy-windows-x86_64:
           filters:
             branches:
               only: release
@@ -189,11 +192,11 @@ workflows:
             branches:
               only: release
           requires:
-            - build-linux-arm64
-            - build-linux-x86_64
-            - build-mac-arm64
-            - build-mac-x86_64
-            - build-windows-x86_64
+            - deploy-linux-arm64
+            - deploy-linux-x86_64
+            - deploy-mac-arm64
+            - deploy-mac-x86_64
+            - deploy-windows-x86_64
       - deploy-brew:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,10 +166,6 @@ jobs:
     steps:
       - checkout
       - install-bazel-mac
-      - run: |
-          export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
-          export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
-          bazel run @vaticle_dependencies//distribution/artifact:create-netrc
       - deploy-mac-release:
           target-arch: arm64
       - run: |
@@ -184,10 +180,6 @@ jobs:
     steps:
       - checkout
       - install-bazel-mac
-      - run: |
-          export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
-          export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
-          bazel run @vaticle_dependencies//distribution/artifact:create-netrc
       - deploy-mac-release:
           target-arch: x86_64
       - run: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,6 @@ jobs:
       - run: |
           export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
           export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
-          bazel run @vaticle_dependencies//distribution/artifact:create-netrc
       - deploy-mac-snapshot:
           target-arch: arm64
 
@@ -109,7 +108,6 @@ jobs:
       - run: |
           export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
           export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
-          bazel run @vaticle_dependencies//distribution/artifact:create-netrc
       - deploy-mac-snapshot:
           target-arch: x86_64
 
@@ -119,6 +117,8 @@ jobs:
       - checkout
       - install-bazel-linux-arm64
       - run: |
+          export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+          export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
           # TODO Temporary measure. This exists for two reasons:
           # 1) platform-jvm assembly rules currently requires the version to be specified in a version_file
           # 2) jpackage does not support 0 as a major version
@@ -132,6 +132,8 @@ jobs:
       - checkout
       - install-bazel-linux-x86_64
       - run: |
+          export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+          export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
           # TODO Temporary measure. This exists for two reasons:
           # 1) platform-jvm assembly rules currently requires the version to be specified in a version_file
           # 2) jpackage does not support 0 as a major version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,15 +61,30 @@ commands:
     steps:
       - run: brew install bazelisk
 
-  deploy-mac:
+  deploy-mac-snapshot:
     parameters:
       target-arch:
         type: string
     steps:
-      - run: bazel run //:deploy-mac-<<parameters.target-arch>>-dmg --compilation_mode=opt --define APPLE_CODE_SIGN=yes --define APPLE_ID=$APPLE_ID --define APPLE_ID_PASSWORD=$APPLE_ID_PASSWORD --define APPLE_TEAM_ID=$APPLE_TEAM_ID --define APPLE_CODE_SIGNING_CERT_PASSWORD=$APPLE_CODE_SIGNING_CERT_PASSWORD --spawn_strategy=local
+      - run: |
+          bazel run --define version=$(git rev-parse HEAD) //:deploy-mac-<<parameters.target-arch>>-dmg --compilation_mode=opt --spawn_strategy=local -- snapshot
+
+  deploy-mac-release:
+    parameters:
+      target-arch:
+        type: string
+    steps:
+      - run: |
+          bazel run //:deploy-mac-<<parameters.target-arch>>-dmg --compilation_mode=opt \
+              --define APPLE_CODE_SIGN=yes \
+              --define APPLE_ID=$APPLE_ID \
+              --define APPLE_ID_PASSWORD=$APPLE_ID_PASSWORD \
+              --define APPLE_TEAM_ID=$APPLE_TEAM_ID \
+              --define APPLE_CODE_SIGNING_CERT_PASSWORD=$APPLE_CODE_SIGNING_CERT_PASSWORD \
+              --spawn_strategy=local -- release
 
 jobs:
-  deploy-mac-arm64:
+  deploy-mac-arm64-snapshot:
     executor: mac-arm64
     steps:
       - checkout
@@ -78,16 +93,10 @@ jobs:
           export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
           export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
           bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-      - deploy-mac:
+      - deploy-mac-snapshot:
           target-arch: arm64
-      - run: |
-          mkdir -p ~/dist && cp bazel-bin/typedb-studio-mac-arm64-*.dmg ~/dist
-      - persist_to_workspace:
-          root: ~/dist
-          paths:
-            - ./*
 
-  deploy-mac-x86_64:
+  deploy-mac-x86_64-snapshot:
     executor: mac-x86_64
     steps:
       - checkout
@@ -96,7 +105,61 @@ jobs:
           export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
           export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
           bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-      - deploy-mac:
+      - deploy-mac-snapshot:
+          target-arch: x86_64
+
+  deploy-linux-arm64-snapshot:
+    executor: linux-arm64
+    steps:
+      - checkout
+      - install-bazel-linux-arm64
+      - run: bazel run --define version=$(git rev-parse HEAD) //:deploy-linux-arm64-targz --compilation_mode=opt -- snapshot
+
+  deploy-linux-x86_64-snapshot:
+    executor: linux-x86_64
+    steps:
+      - checkout
+      - install-bazel-linux-x86_64
+      - run: bazel run --define version=$(git rev-parse HEAD) //:deploy-linux-x86_64-targz --compilation_mode=opt -- snapshot
+
+  deploy-windows-x86_64-snapshot:
+    executor:
+      name: win/default
+      shell: cmd.exe
+    working_directory: ~/typedb-studio
+    steps:
+      - checkout
+      - run: .circleci\windows\prepare.bat
+      - run: .circleci\windows\deploy_snapshot.bat
+
+  deploy-mac-arm64-release:
+    executor: mac-arm64
+    steps:
+      - checkout
+      - install-bazel-mac
+      - run: |
+          export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+          export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
+          bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+      - deploy-mac-release:
+          target-arch: arm64
+      - run: |
+          mkdir -p ~/dist && cp bazel-bin/typedb-studio-mac-arm64-*.dmg ~/dist
+      - persist_to_workspace:
+          root: ~/dist
+          paths:
+            - ./*
+
+  deploy-mac-x86_64-release:
+    executor: mac-x86_64
+    steps:
+      - checkout
+      - install-bazel-mac
+      - run: |
+          export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+          export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
+          bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+      - deploy-mac-release:
           target-arch: x86_64
       - run: |
           mkdir -p ~/dist && cp bazel-bin/typedb-studio-mac-x86_64-*.dmg ~/dist
@@ -105,23 +168,23 @@ jobs:
           paths:
             - ./*
 
-  deploy-linux-arm64:
+  deploy-linux-arm64-release:
     executor: linux-arm64
     steps:
       - checkout
       - install-bazel-linux-arm64
-      - run: bazel run //:deploy-linux-arm64-deb --compilation_mode=opt
-      - run: bazel run //:deploy-linux-arm64-targz --compilation_mode=opt
+      - run: bazel run //:deploy-linux-arm64-deb --compilation_mode=opt -- release
+      - run: bazel run //:deploy-linux-arm64-targz --compilation_mode=opt -- release
 
-  deploy-linux-x86_64:
+  deploy-linux-x86_64-release:
     executor: linux-x86_64
     steps:
       - checkout
       - install-bazel-linux-x86_64
-      - run: bazel run //:deploy-linux-x86_64-deb --compilation_mode=opt
-      - run: bazel run //:deploy-linux-x86_64-targz --compilation_mode=opt
+      - run: bazel run //:deploy-linux-x86_64-deb --compilation_mode=opt -- release
+      - run: bazel run //:deploy-linux-x86_64-targz --compilation_mode=opt -- release
 
-  deploy-windows-x86_64:
+  deploy-windows-x86_64-release:
     executor:
       name: win/default
       shell: cmd.exe
@@ -129,7 +192,7 @@ jobs:
     steps:
       - checkout
       - run: .circleci\windows\prepare.bat
-      - run: .circleci\windows\deploy.bat
+      - run: .circleci\windows\deploy_release.bat
 
   deploy-github:
     executor: linux-x86_64
@@ -165,25 +228,47 @@ jobs:
       - run: git push --delete https://$REPO_GITHUB_TOKEN@github.com/vaticle/typedb-studio.git $CIRCLE_BRANCH
 
 workflows:
+  snapshot:
+    jobs:
+      - deploy-linux-arm64-snapshot:
+          filters:
+            branches:
+              only: [master, development]
+      - deploy-linux-x86_64-snapshot:
+          filters:
+            branches:
+              only: [master, development]
+      - deploy-mac-arm64-snapshot:
+          filters:
+            branches:
+              only: [master, development]
+      - deploy-mac-x86_64-snapshot:
+          filters:
+            branches:
+              only: [master, development]
+      - deploy-windows-x86_64-snapshot:
+          filters:
+            branches:
+              only: [master, development]
   release:
     jobs:
-      - deploy-linux-arm64:
+      - deploy-linux-arm64-release:
           filters:
             branches:
               only: release
-      - deploy-linux-x86_64:
+      - deploy-linux-x86_64-release:
           filters:
             branches:
               only: release
-      - deploy-mac-arm64:
+      - deploy-mac-arm64-release:
           filters:
             branches:
               only: release
-      - deploy-mac-x86_64:
+      - deploy-mac-x86_64-release:
           filters:
             branches:
               only: release
-      - deploy-windows-x86_64:
+      - deploy-windows-x86_64-release:
           filters:
             branches:
               only: release
@@ -192,11 +277,11 @@ workflows:
             branches:
               only: release
           requires:
-            - deploy-linux-arm64
-            - deploy-linux-x86_64
-            - deploy-mac-arm64
-            - deploy-mac-x86_64
-            - deploy-windows-x86_64
+            - deploy-linux-arm64-release
+            - deploy-linux-x86_64-release
+            - deploy-mac-arm64-release
+            - deploy-mac-x86_64-release
+            - deploy-windows-x86_64-release
       - deploy-brew:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,12 @@ commands:
         type: string
     steps:
       - run: |
-          bazel run --define version=$(git rev-parse HEAD) //:deploy-mac-<<parameters.target-arch>>-dmg --compilation_mode=opt --spawn_strategy=local -- snapshot
+          # TODO Temporary measure. This exists for two reasons:
+          # 1) platform-jvm assembly rules currently requires the version to be specified in a version_file
+          # 2) jpackage does not support 0 as a major version
+          # This writes VERSION-SHA1 into the VERSION file to be used by the assembly rule.
+          echo $(cat VERSION)-$CIRCLE_SHA1 > VERSION
+          bazel run //:deploy-mac-<<parameters.target-arch>>-dmg --compilation_mode=opt --spawn_strategy=local -- snapshot
 
   deploy-mac-release:
     parameters:
@@ -113,14 +118,26 @@ jobs:
     steps:
       - checkout
       - install-bazel-linux-arm64
-      - run: bazel run --define version=$(git rev-parse HEAD) //:deploy-linux-arm64-targz --compilation_mode=opt -- snapshot
+      - run: |
+          # TODO Temporary measure. This exists for two reasons:
+          # 1) platform-jvm assembly rules currently requires the version to be specified in a version_file
+          # 2) jpackage does not support 0 as a major version
+          # This writes VERSION-SHA1 into the VERSION file to be used by the assembly rule.
+          echo $(cat VERSION)-$CIRCLE_SHA1 > VERSION
+          bazel run //:deploy-linux-arm64-targz --compilation_mode=opt -- snapshot
 
   deploy-linux-x86_64-snapshot:
     executor: linux-x86_64
     steps:
       - checkout
       - install-bazel-linux-x86_64
-      - run: bazel run --define version=$(git rev-parse HEAD) //:deploy-linux-x86_64-targz --compilation_mode=opt -- snapshot
+      - run: |
+          # TODO Temporary measure. This exists for two reasons:
+          # 1) platform-jvm assembly rules currently requires the version to be specified in a version_file
+          # 2) jpackage does not support 0 as a major version
+          # This writes VERSION-SHA1 into the VERSION file to be used by the assembly rule.
+          echo $(cat VERSION)-$CIRCLE_SHA1 > VERSION
+          bazel run //:deploy-linux-x86_64-targz --compilation_mode=opt -- snapshot
 
   deploy-windows-x86_64-snapshot:
     executor:

--- a/.circleci/windows/deploy.bat
+++ b/.circleci/windows/deploy.bat
@@ -20,11 +20,5 @@ REM by Chocolatey in prepare.bat is accessible
 CALL refreshenv
 
 ECHO Building Windows application image...
-bazel --output_user_root=C:/b build //:assemble-platform --compilation_mode=opt
-IF %errorlevel% NEQ 0 EXIT /b %errorlevel%
-
-ECHO Extracting application image archive...
-mkdir dist
-cd dist
-jar xf ..\bazel-bin\assemble-platform.zip
+bazel --output_user_root=C:/b run //:deploy-windows-x86_64-exe --compilation_mode=opt
 IF %errorlevel% NEQ 0 EXIT /b %errorlevel%

--- a/.circleci/windows/deploy_release.bat
+++ b/.circleci/windows/deploy_release.bat
@@ -20,5 +20,9 @@ REM by Chocolatey in prepare.bat is accessible
 CALL refreshenv
 
 ECHO Building Windows application image...
+
+SET DEPLOY_ARTIFACT_USERNAME=%REPO_TYPEDB_USERNAME%
+SET DEPLOY_ARTIFACT_PASSWORD=%REPO_TYPEDB_PASSWORD%
+
 bazel --output_user_root=C:/b run //:deploy-windows-x86_64-exe --compilation_mode=opt -- release
 IF %errorlevel% NEQ 0 EXIT /b %errorlevel%

--- a/.circleci/windows/deploy_release.bat
+++ b/.circleci/windows/deploy_release.bat
@@ -20,5 +20,5 @@ REM by Chocolatey in prepare.bat is accessible
 CALL refreshenv
 
 ECHO Building Windows application image...
-bazel --output_user_root=C:/b run //:deploy-windows-x86_64-exe --compilation_mode=opt
+bazel --output_user_root=C:/b run //:deploy-windows-x86_64-exe --compilation_mode=opt -- release
 IF %errorlevel% NEQ 0 EXIT /b %errorlevel%

--- a/.circleci/windows/deploy_snapshot.bat
+++ b/.circleci/windows/deploy_snapshot.bat
@@ -20,5 +20,12 @@ REM by Chocolatey in prepare.bat is accessible
 CALL refreshenv
 
 ECHO Building Windows application image...
-bazel --output_user_root=C:/b --define version=%CIRCLE_SHA1% run //:deploy-windows-x86_64-exe --compilation_mode=opt -- snapshot
+
+REM TODO Temporary measure. This exists for two reasons:
+REM 1) platform-jvm assembly rules currently requires the version to be specified in a version_file
+REM 2) jpackage does not support 0 as a major version
+REM This writes VERSION-SHA1 into the VERSION file to be used by the assembly rule.
+FOR /F "tokens=*" %%V IN (VERSION) DO (SET VERS=%%V) & ECHO %VERS%-%CIRCLE_SHA%> VERSION
+
+bazel --output_user_root=C:/b run //:deploy-windows-x86_64-exe --compilation_mode=opt -- snapshot
 IF %errorlevel% NEQ 0 EXIT /b %errorlevel%

--- a/.circleci/windows/deploy_snapshot.bat
+++ b/.circleci/windows/deploy_snapshot.bat
@@ -1,0 +1,24 @@
+REM
+REM Copyright (C) 2021 Vaticle
+REM
+REM This program is free software: you can redistribute it and/or modify
+REM it under the terms of the GNU Affero General Public License as
+REM published by the Free Software Foundation, either version 3 of the
+REM License, or (at your option) any later version.
+REM
+REM This program is distributed in the hope that it will be useful,
+REM but WITHOUT ANY WARRANTY; without even the implied warranty of
+REM MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+REM GNU Affero General Public License for more details.
+REM
+REM You should have received a copy of the GNU Affero General Public License
+REM along with this program.  If not, see <https://www.gnu.org/licenses/>.
+REM
+
+REM needs to be called such that software installed
+REM by Chocolatey in prepare.bat is accessible
+CALL refreshenv
+
+ECHO Building Windows application image...
+bazel --output_user_root=C:/b --define version=%CIRCLE_SHA1% run //:deploy-windows-x86_64-exe --compilation_mode=opt -- snapshot
+IF %errorlevel% NEQ 0 EXIT /b %errorlevel%

--- a/.circleci/windows/deploy_snapshot.bat
+++ b/.circleci/windows/deploy_snapshot.bat
@@ -28,5 +28,8 @@ REM This writes VERSION-SHA1 into the VERSION file to be used by the assembly ru
 FOR /F "tokens=*" %%V IN (VERSION) DO (SET VERS=%%V)
 ECHO %VERS%-%CIRCLE_SHA1%> VERSION
 
+SET DEPLOY_ARTIFACT_USERNAME=%REPO_TYPEDB_USERNAME%
+SET DEPLOY_ARTIFACT_PASSWORD=%REPO_TYPEDB_PASSWORD%
+
 bazel --output_user_root=C:/b run //:deploy-windows-x86_64-exe --compilation_mode=opt -- snapshot
 IF %errorlevel% NEQ 0 EXIT /b %errorlevel%

--- a/.circleci/windows/deploy_snapshot.bat
+++ b/.circleci/windows/deploy_snapshot.bat
@@ -25,7 +25,8 @@ REM TODO Temporary measure. This exists for two reasons:
 REM 1) platform-jvm assembly rules currently requires the version to be specified in a version_file
 REM 2) jpackage does not support 0 as a major version
 REM This writes VERSION-SHA1 into the VERSION file to be used by the assembly rule.
-FOR /F "tokens=*" %%V IN (VERSION) DO (SET VERS=%%V) & ECHO %VERS%-%CIRCLE_SHA%> VERSION
+FOR /F "tokens=*" %%V IN (VERSION) DO (SET VERS=%%V)
+ECHO %VERS%-%CIRCLE_SHA1%> VERSION
 
 bazel --output_user_root=C:/b run //:deploy-windows-x86_64-exe --compilation_mode=opt -- snapshot
 IF %errorlevel% NEQ 0 EXIT /b %errorlevel%

--- a/BUILD
+++ b/BUILD
@@ -212,30 +212,35 @@ unzip_file(
     name = "native-artifact-mac-arm64-dmg",
     target = ":assemble-platform",
     output = "typedb-studio-mac-arm64.dmg",
+    target_compatible_with = constraint_mac_arm64,
 )
 
 unzip_file(
     name = "native-artifact-mac-x86_64-dmg",
     target = ":assemble-platform",
     output = "typedb-studio-mac-x86_64.dmg",
+    target_compatible_with = constraint_mac_x86_64,
 )
 
 unzip_file(
     name = "native-artifact-linux-arm64-tar-gz",
     target = ":assemble-platform",
     output = "typedb-studio-linux-arm64.tar.gz",
+    target_compatible_with = constraint_linux_arm64,
 )
 
 unzip_file(
     name = "native-artifact-linux-x86_64-tar-gz",
     target = ":assemble-platform",
     output = "typedb-studio-linux-x86_64.tar.gz",
+    target_compatible_with = constraint_linux_x86_64,
 )
 
 unzip_file(
     name = "native-artifact-windows-x86_64-exe",
     target = ":assemble-platform",
     output = "typedb-studio-windows-x86_64.exe",
+    target_compatible_with = constraint_win_x86_64,
 )
 
 deploy_artifact(
@@ -246,6 +251,7 @@ deploy_artifact(
     snapshot = deployment['artifact']['snapshot']['upload'],
     release = deployment['artifact']['release']['upload'],
     visibility = ["//visibility:public"],
+    target_compatible_with = constraint_mac_x86_64,
 )
 
 deploy_artifact(
@@ -256,6 +262,7 @@ deploy_artifact(
     snapshot = deployment['artifact']['snapshot']['upload'],
     release = deployment['artifact']['release']['upload'],
     visibility = ["//visibility:public"],
+    target_compatible_with = constraint_mac_arm64,
 )
 
 deploy_artifact(
@@ -266,6 +273,7 @@ deploy_artifact(
     snapshot = deployment['artifact']['snapshot']['upload'],
     release = deployment['artifact']['release']['upload'],
     visibility = ["//visibility:public"],
+    target_compatible_with = constraint_linux_x86_64,
 )
 
 deploy_artifact(
@@ -276,6 +284,7 @@ deploy_artifact(
     snapshot = deployment['artifact']['snapshot']['upload'],
     release = deployment['artifact']['release']['upload'],
     visibility = ["//visibility:public"],
+    target_compatible_with = constraint_linux_arm64,
 )
 
 deploy_artifact(
@@ -286,6 +295,7 @@ deploy_artifact(
     snapshot = deployment['artifact']['snapshot']['upload'],
     release = deployment['artifact']['release']['upload'],
     visibility = ["//visibility:public"],
+    target_compatible_with = constraint_win_x86_64,
 )
 
 label_flag(

--- a/BUILD
+++ b/BUILD
@@ -250,6 +250,7 @@ deploy_artifact(
     artifact_name = "typedb-studio-mac-x86_64-{version}.dmg",
     snapshot = deployment['artifact']['snapshot']['upload'],
     release = deployment['artifact']['release']['upload'],
+    version_file = ":VERSION",
     visibility = ["//visibility:public"],
     target_compatible_with = constraint_mac_x86_64,
 )
@@ -261,6 +262,7 @@ deploy_artifact(
     artifact_name = "typedb-studio-mac-arm64-{version}.dmg",
     snapshot = deployment['artifact']['snapshot']['upload'],
     release = deployment['artifact']['release']['upload'],
+    version_file = ":VERSION",
     visibility = ["//visibility:public"],
     target_compatible_with = constraint_mac_arm64,
 )
@@ -272,6 +274,7 @@ deploy_artifact(
     artifact_name = "typedb-studio-linux-x86_64-{version}.deb",
     snapshot = deployment['artifact']['snapshot']['upload'],
     release = deployment['artifact']['release']['upload'],
+    version_file = ":VERSION",
     visibility = ["//visibility:public"],
     target_compatible_with = constraint_linux_x86_64,
 )
@@ -283,6 +286,7 @@ deploy_artifact(
     artifact_name = "typedb-studio-linux-x86_64-{version}.tar.gz",
     snapshot = deployment['artifact']['snapshot']['upload'],
     release = deployment['artifact']['release']['upload'],
+    version_file = ":VERSION",
     visibility = ["//visibility:public"],
     target_compatible_with = constraint_linux_x86_64,
 )
@@ -294,6 +298,7 @@ deploy_artifact(
     artifact_name = "typedb-studio-linux-arm64-{version}.deb",
     snapshot = deployment['artifact']['snapshot']['upload'],
     release = deployment['artifact']['release']['upload'],
+    version_file = ":VERSION",
     visibility = ["//visibility:public"],
     target_compatible_with = constraint_linux_arm64,
 )
@@ -305,6 +310,7 @@ deploy_artifact(
     artifact_name = "typedb-studio-linux-arm64-{version}.tar.gz",
     snapshot = deployment['artifact']['snapshot']['upload'],
     release = deployment['artifact']['release']['upload'],
+    version_file = ":VERSION",
     visibility = ["//visibility:public"],
     target_compatible_with = constraint_linux_arm64,
 )
@@ -316,6 +322,7 @@ deploy_artifact(
     artifact_name = "typedb-studio-windows-x86_64-{version}.exe",
     snapshot = deployment['artifact']['snapshot']['upload'],
     release = deployment['artifact']['release']['upload'],
+    version_file = ":VERSION",
     visibility = ["//visibility:public"],
     target_compatible_with = constraint_win_x86_64,
 )

--- a/BUILD
+++ b/BUILD
@@ -27,7 +27,7 @@ load("@vaticle_bazel_distribution//brew:rules.bzl", "deploy_brew")
 load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_library")
 load("@io_bazel_rules_kotlin//kotlin/internal:toolchains.bzl", "define_kt_toolchain")
 load("@vaticle_bazel_distribution//platform/jvm:rules.bzl", "assemble_jvm_platform")
-load("@vaticle_bazel_distribution//artifact:rules.bzl", "artifact_extractor")
+load("@vaticle_bazel_distribution//artifact:rules.bzl", "artifact_extractor", "deploy_artifact")
 load("@vaticle_bazel_distribution//platform:constraints.bzl", "constraint_linux_arm64", "constraint_linux_x86_64",
      "constraint_mac_arm64", "constraint_mac_x86_64", "constraint_win_x86_64")
 

--- a/BUILD
+++ b/BUILD
@@ -223,16 +223,16 @@ unzip_file(
 )
 
 unzip_file(
-    name = "native-artifact-linux-arm64-tar-gz",
+    name = "native-artifact-linux-arm64-deb",
     target = ":assemble-platform",
-    output = "typedb-studio-linux-arm64.tar.gz",
+    output = "typedb-studio-linux-arm64.deb",
     target_compatible_with = constraint_linux_arm64,
 )
 
 unzip_file(
-    name = "native-artifact-linux-x86_64-tar-gz",
+    name = "native-artifact-linux-x86_64-deb",
     target = ":assemble-platform",
-    output = "typedb-studio-linux-x86_64.tar.gz",
+    output = "typedb-studio-linux-x86_64.deb",
     target_compatible_with = constraint_linux_x86_64,
 )
 
@@ -266,8 +266,19 @@ deploy_artifact(
 )
 
 deploy_artifact(
+    name = "deploy-linux-x86_64-deb",
+    target = ":native-artifact-linux-x86_64-deb",
+    artifact_group = "typedb-studio-linux-x86_64",
+    artifact_name = "typedb-studio-linux-x86_64-{version}.deb",
+    snapshot = deployment['artifact']['snapshot']['upload'],
+    release = deployment['artifact']['release']['upload'],
+    visibility = ["//visibility:public"],
+    target_compatible_with = constraint_linux_x86_64,
+)
+
+deploy_artifact(
     name = "deploy-linux-x86_64-targz",
-    target = ":native-artifact-linux-x86_64-targz",
+    target = ":assemble-linux-targz",
     artifact_group = "typedb-studio-linux-x86_64",
     artifact_name = "typedb-studio-linux-x86_64-{version}.tar.gz",
     snapshot = deployment['artifact']['snapshot']['upload'],
@@ -277,14 +288,25 @@ deploy_artifact(
 )
 
 deploy_artifact(
+    name = "deploy-linux-arm64-deb",
+    target = ":native-artifact-linux-arm64-deb",
+    artifact_group = "typedb-studio-linux-arm64",
+    artifact_name = "typedb-studio-linux-arm64-{version}.deb",
+    snapshot = deployment['artifact']['snapshot']['upload'],
+    release = deployment['artifact']['release']['upload'],
+    visibility = ["//visibility:public"],
+    target_compatible_with = constraint_linux_arm64,
+)
+
+deploy_artifact(
     name = "deploy-linux-arm64-targz",
-    target = ":native-artifact-linux-arm64-targz",
+    target = ":assemble-linux-targz",
     artifact_group = "typedb-studio-linux-arm64",
     artifact_name = "typedb-studio-linux-arm64-{version}.tar.gz",
     snapshot = deployment['artifact']['snapshot']['upload'],
     release = deployment['artifact']['release']['upload'],
     visibility = ["//visibility:public"],
-    target_compatible_with = constraint_linux_arm64,
+    target_compatible_with = constraint_linux_x86_64,
 )
 
 deploy_artifact(

--- a/BUILD
+++ b/BUILD
@@ -15,16 +15,12 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-load("//:deployment.bzl", deployment_github = "deployment")
-load("@rules_pkg//:pkg.bzl", "pkg_zip")
 load("@vaticle_dependencies//distribution:deployment.bzl", "deployment")
 load("@vaticle_dependencies//builder/java:rules.bzl", "native_typedb_artifact")
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
-load("@vaticle_bazel_distribution//common:rules.bzl", "assemble_targz", "assemble_versioned", "assemble_zip", "unzip_file", "checksum", "java_deps")
-load("@vaticle_bazel_distribution//common/tgz2zip:rules.bzl", "tgz2zip")
-load("@vaticle_bazel_distribution//github:rules.bzl", "deploy_github")
+load("@vaticle_bazel_distribution//common:rules.bzl", "assemble_targz", "unzip_file", "checksum", "java_deps")
 load("@vaticle_bazel_distribution//brew:rules.bzl", "deploy_brew")
-load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 load("@io_bazel_rules_kotlin//kotlin/internal:toolchains.bzl", "define_kt_toolchain")
 load("@vaticle_bazel_distribution//platform/jvm:rules.bzl", "assemble_jvm_platform")
 load("@vaticle_bazel_distribution//artifact:rules.bzl", "artifact_extractor", "deploy_artifact")

--- a/BUILD
+++ b/BUILD
@@ -20,7 +20,7 @@ load("@rules_pkg//:pkg.bzl", "pkg_zip")
 load("@vaticle_dependencies//distribution:deployment.bzl", "deployment")
 load("@vaticle_dependencies//builder/java:rules.bzl", "native_typedb_artifact")
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
-load("@vaticle_bazel_distribution//common:rules.bzl", "assemble_targz", "assemble_versioned", "assemble_zip", "unzip", "checksum", "java_deps")
+load("@vaticle_bazel_distribution//common:rules.bzl", "assemble_targz", "assemble_versioned", "assemble_zip", "unzip_file", "checksum", "java_deps")
 load("@vaticle_bazel_distribution//common/tgz2zip:rules.bzl", "tgz2zip")
 load("@vaticle_bazel_distribution//github:rules.bzl", "deploy_github")
 load("@vaticle_bazel_distribution//brew:rules.bzl", "deploy_brew")
@@ -208,10 +208,84 @@ genrule(
     cmd = "echo > $@",
 )
 
-unzip(
-    name = "native-artifact",
+unzip_file(
+    name = "native-artifact-mac-arm64-dmg",
     target = ":assemble-platform",
-    outs = ["typedb-studio-mac-arm64-2.26.0.dmg"],
+    output = "typedb-studio-mac-arm64.dmg",
+)
+
+unzip_file(
+    name = "native-artifact-mac-x86_64-dmg",
+    target = ":assemble-platform",
+    output = "typedb-studio-mac-x86_64.dmg",
+)
+
+unzip_file(
+    name = "native-artifact-linux-arm64-tar-gz",
+    target = ":assemble-platform",
+    output = "typedb-studio-linux-arm64.tar.gz",
+)
+
+unzip_file(
+    name = "native-artifact-linux-x86_64-tar-gz",
+    target = ":assemble-platform",
+    output = "typedb-studio-linux-x86_64.tar.gz",
+)
+
+unzip_file(
+    name = "native-artifact-windows-x86_64-exe",
+    target = ":assemble-platform",
+    output = "typedb-studio-windows-x86_64.exe",
+)
+
+deploy_artifact(
+    name = "deploy-mac-x86_64-dmg",
+    target = ":native-artifact-mac-x86_64-dmg",
+    artifact_group = "typedb-studio-mac-x86_64",
+    artifact_name = "typedb-studio-mac-x86_64-{version}.dmg",
+    snapshot = deployment['artifact']['snapshot']['upload'],
+    release = deployment['artifact']['release']['upload'],
+    visibility = ["//visibility:public"],
+)
+
+deploy_artifact(
+    name = "deploy-mac-arm64-dmg",
+    target = ":native-artifact-mac-arm64-dmg",
+    artifact_group = "typedb-studio-mac-arm64",
+    artifact_name = "typedb-studio-mac-arm64-{version}.dmg",
+    snapshot = deployment['artifact']['snapshot']['upload'],
+    release = deployment['artifact']['release']['upload'],
+    visibility = ["//visibility:public"],
+)
+
+deploy_artifact(
+    name = "deploy-linux-x86_64-targz",
+    target = ":native-artifact-linux-x86_64-targz",
+    artifact_group = "typedb-studio-linux-x86_64",
+    artifact_name = "typedb-studio-linux-x86_64-{version}.tar.gz",
+    snapshot = deployment['artifact']['snapshot']['upload'],
+    release = deployment['artifact']['release']['upload'],
+    visibility = ["//visibility:public"],
+)
+
+deploy_artifact(
+    name = "deploy-linux-arm64-targz",
+    target = ":native-artifact-linux-arm64-targz",
+    artifact_group = "typedb-studio-linux-arm64",
+    artifact_name = "typedb-studio-linux-arm64-{version}.tar.gz",
+    snapshot = deployment['artifact']['snapshot']['upload'],
+    release = deployment['artifact']['release']['upload'],
+    visibility = ["//visibility:public"],
+)
+
+deploy_artifact(
+    name = "deploy-windows-x86_64-exe",
+    target = ":native-artifact-windows-x86_64-exe",
+    artifact_group = "typedb-studio-windows-x86_64",
+    artifact_name = "typedb-studio-windows-x86_64-{version}.exe",
+    snapshot = deployment['artifact']['snapshot']['upload'],
+    release = deployment['artifact']['release']['upload'],
+    visibility = ["//visibility:public"],
 )
 
 label_flag(

--- a/BUILD
+++ b/BUILD
@@ -20,7 +20,7 @@ load("@rules_pkg//:pkg.bzl", "pkg_zip")
 load("@vaticle_dependencies//distribution:deployment.bzl", "deployment")
 load("@vaticle_dependencies//builder/java:rules.bzl", "native_typedb_artifact")
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
-load("@vaticle_bazel_distribution//common:rules.bzl", "assemble_targz", "assemble_versioned", "assemble_zip", "checksum", "java_deps")
+load("@vaticle_bazel_distribution//common:rules.bzl", "assemble_targz", "assemble_versioned", "assemble_zip", "unzip", "checksum", "java_deps")
 load("@vaticle_bazel_distribution//common/tgz2zip:rules.bzl", "tgz2zip")
 load("@vaticle_bazel_distribution//github:rules.bzl", "deploy_github")
 load("@vaticle_bazel_distribution//brew:rules.bzl", "deploy_brew")
@@ -55,7 +55,7 @@ kt_jvm_library(
         "//framework/material:material",
 
         # External Vaticle Dependencies
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
 
         # External Maven Dependencies
         "@maven//:io_github_microutils_kotlin_logging_jvm",
@@ -206,6 +206,12 @@ genrule(
     outs = ["invalid-checksum.txt"],
     srcs = [],
     cmd = "echo > $@",
+)
+
+unzip(
+    name = "native-artifact",
+    target = ":assemble-platform",
+    outs = ["typedb-studio-mac-arm64-2.26.0.dmg"],
 )
 
 label_flag(

--- a/BUILD
+++ b/BUILD
@@ -306,7 +306,7 @@ deploy_artifact(
     snapshot = deployment['artifact']['snapshot']['upload'],
     release = deployment['artifact']['release']['upload'],
     visibility = ["//visibility:public"],
-    target_compatible_with = constraint_linux_x86_64,
+    target_compatible_with = constraint_linux_arm64,
 )
 
 deploy_artifact(

--- a/RELEASE_TEMPLATE.md
+++ b/RELEASE_TEMPLATE.md
@@ -1,6 +1,6 @@
 ### Distribution
 
-TypeDB Studio is available for Linux, Mac and Windows (download binaries below).
+TypeDB Studio is available for Linux, Mac and Windows. [Download TypeDB Studio {version}.](https://cloudsmith.io/~typedb/repos/public-release/packages/?q=name:^typedb-studio+version:{version})
 
 For Mac Intel and Mac ARM, TypeDB Studio is also available through Homebrew:
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -119,6 +119,12 @@ vaticle_bazel_distribution()
 load("@vaticle_bazel_distribution//pip:deps.bzl", pip_deps = "deps")
 pip_deps()
 
+# Load @vaticle_bazel_distribution_uploader
+load("@vaticle_bazel_distribution//common/uploader:deps.bzl", uploader_deps = "deps")
+uploader_deps()
+load("@vaticle_bazel_distribution_uploader//:requirements.bzl", install_uploader_deps = "install_deps")
+install_uploader_deps()
+
 # Load //github
 load("@vaticle_bazel_distribution//github:deps.bzl", github_deps = "deps")
 github_deps()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -152,26 +152,18 @@ google_common_workspace_rules()
 ################################
 
 # Load repositories
-load(
-    "//dependencies/vaticle:repositories.bzl",
-    "vaticle_force_graph", "vaticle_typedb_common", "vaticle_typedb_driver"
-)
+load("//dependencies/vaticle:repositories.bzl", "vaticle_force_graph", "vaticle_typedb_driver", "vaticle_typeql")
 vaticle_force_graph()
-vaticle_typedb_common()
 vaticle_typedb_driver()
-
-load(
-    "@vaticle_typedb_driver//dependencies/vaticle:repositories.bzl",
-    "vaticle_typedb_protocol", "vaticle_typeql"
-)
 vaticle_typeql()
+
+load("@vaticle_typedb_driver//dependencies/vaticle:repositories.bzl", "vaticle_typedb_protocol")
 vaticle_typedb_protocol()
 
 # Load Maven
 load("//dependencies/vaticle:artifacts.bzl", vaticle_typedb_studio_vaticle_maven_artifacts = "maven_artifacts")
 load("@vaticle_typeql//dependencies/maven:artifacts.bzl", vaticle_typeql_artifacts = "artifacts")
 load("@vaticle_typedb_driver//dependencies/maven:artifacts.bzl", vaticle_typedb_driver_artifacts = "artifacts")
-load("@vaticle_typedb_common//dependencies/maven:artifacts.bzl", vaticle_typedb_common_artifacts = "artifacts")
 load("@vaticle_force_graph//dependencies/maven:artifacts.bzl", vaticle_force_graph_artifacts = "artifacts")
 
 ############################
@@ -182,7 +174,6 @@ maven(
     vaticle_dependencies_tool_maven_artifacts +
     vaticle_typeql_artifacts +
     vaticle_typedb_driver_artifacts +
-    vaticle_typedb_common_artifacts +
     vaticle_force_graph_artifacts +
     vaticle_typedb_studio_artifacts,
     internal_artifacts = vaticle_typedb_studio_vaticle_maven_artifacts,

--- a/config/brew/typedb-studio.rb
+++ b/config/brew/typedb-studio.rb
@@ -19,12 +19,12 @@ cask 'typedb-studio' do
   version '{version}'
 
   on_arm do
-    url "https://repo.typedb.com/public/public-release/raw/names/typedb-studio-mac-arm64/versions/{version}/typedb-studio-windows-arm64-{version}.zip"
+    url "https://repo.typedb.com/public/public-release/raw/names/typedb-studio-mac-arm64/versions/{version}/typedb-studio-mac-arm64-{version}.dmg"
     sha256 "{sha256-arm64}"
   end
 
   on_intel do
-    url "https://repo.typedb.com/public/public-release/raw/names/typedb-studio-mac-x86_64/versions/{version}/typedb-studio-windows-x86_64-{version}.zip"
+    url "https://repo.typedb.com/public/public-release/raw/names/typedb-studio-mac-x86_64/versions/{version}/typedb-studio-mac-x86_64-{version}.dmg"
     sha256 "{sha256-x86_64}"
   end
 

--- a/config/brew/typedb-studio.rb
+++ b/config/brew/typedb-studio.rb
@@ -19,12 +19,12 @@ cask 'typedb-studio' do
   version '{version}'
 
   on_arm do
-    url "https://github.com/vaticle/typedb-studio/releases/download/{version}/typedb-studio-mac-arm64-{version}.dmg"
+    url "https://repo.typedb.com/public/public-release/raw/names/typedb-studio-mac-arm64/versions/{version}/typedb-studio-windows-arm64-{version}.zip"
     sha256 "{sha256-arm64}"
   end
 
   on_intel do
-    url "https://github.com/vaticle/typedb-studio/releases/download/{version}/typedb-studio-mac-x86_64-{version}.dmg"
+    url "https://repo.typedb.com/public/public-release/raw/names/typedb-studio-mac-x86_64/versions/{version}/typedb-studio-windows-x86_64-{version}.zip"
     sha256 "{sha256-x86_64}"
   end
 

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -18,14 +18,10 @@
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 def vaticle_bazel_distribution():
-    native.local_repository(
-        name = "vaticle_bazel_distribution",
-        path = "../bazel-distribution",
-    )
     git_repository(
-        name = "vaticle_bazel_distribution_",
+        name = "vaticle_bazel_distribution",
         remote = "https://github.com/vaticle/bazel-distribution",
-        commit = "4a01d09ef542a423ced909db9a61291dc0a6acc5",
+        commit = "009311e5b9928396d0ff044583a03728255afc3f",
     )
 
 def vaticle_dependencies():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,14 +21,14 @@ def vaticle_bazel_distribution():
     git_repository(
         name = "vaticle_bazel_distribution",
         remote = "https://github.com/vaticle/bazel-distribution",
-        commit = "009311e5b9928396d0ff044583a03728255afc3f",
+        commit = "6ecb2a5b2d03e8558f17a18fdc0558247cf0d378",
     )
 
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "a4a3bac9515fd51365e02f6aad762f67357e49a5",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "cd00aa9bc16bc2eb857b9b5e4d7a301bf19908dc",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_force_graph():
@@ -42,12 +42,12 @@ def vaticle_typeql():
     git_repository(
         name = "vaticle_typeql",
         remote = "https://github.com/vaticle/typeql",
-        commit = "230842fe545c6ebab59b976df834552d198c6dee",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
+        tag = "2.26.6-rc0",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
     )
 
 def vaticle_typedb_driver():
     git_repository(
         name = "vaticle_typedb_driver",
         remote = "https://github.com/vaticle/typedb-driver",
-        commit = "7ea588b00d990e82a33545a3062296f5b7d5285a",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_driver
+        tag = "2.26.6-rc1",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_driver
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,7 +21,7 @@ def vaticle_bazel_distribution():
     git_repository(
         name = "vaticle_bazel_distribution",
         remote = "https://github.com/vaticle/bazel-distribution",
-        commit = "6ecb2a5b2d03e8558f17a18fdc0558247cf0d378",
+        commit = "31b7140753037c3316e91cfe108616bf62ead05b",
     )
 
 def vaticle_dependencies():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -28,7 +28,7 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "cd00aa9bc16bc2eb857b9b5e4d7a301bf19908dc",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "600a741e7a6c4d58c5ba9c4fcdde43f732cd73b1",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_force_graph():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,14 +21,14 @@ def vaticle_bazel_distribution():
     git_repository(
         name = "vaticle_bazel_distribution",
         remote = "https://github.com/vaticle/bazel-distribution",
-        commit = "31b7140753037c3316e91cfe108616bf62ead05b",
+        commit = "600a741e7a6c4d58c5ba9c4fcdde43f732cd73b1",
     )
 
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "600a741e7a6c4d58c5ba9c4fcdde43f732cd73b1",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "cd00aa9bc16bc2eb857b9b5e4d7a301bf19908dc",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_force_graph():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -18,8 +18,12 @@
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 def vaticle_bazel_distribution():
-    git_repository(
+    native.local_repository(
         name = "vaticle_bazel_distribution",
+        path = "../bazel-distribution",
+    )
+    git_repository(
+        name = "vaticle_bazel_distribution_",
         remote = "https://github.com/vaticle/bazel-distribution",
         commit = "4a01d09ef542a423ced909db9a61291dc0a6acc5",
     )
@@ -38,16 +42,16 @@ def vaticle_force_graph():
         commit = "dc5e7119fc09bafae0acadab1bdc14241337bc7b",
     )
 
-def vaticle_typedb_common():
+def vaticle_typeql():
     git_repository(
-        name = "vaticle_typedb_common",
-        remote = "https://github.com/vaticle/typedb-common",
-        commit = "dbc333528ecdafa5b571344237e831619c3fa5f0",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        name = "vaticle_typeql",
+        remote = "https://github.com/vaticle/typeql",
+        commit = "230842fe545c6ebab59b976df834552d198c6dee",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
     )
 
 def vaticle_typedb_driver():
     git_repository(
         name = "vaticle_typedb_driver",
         remote = "https://github.com/vaticle/typedb-driver",
-        commit = "bc70c4ecec9ce567619e44bfed77f44e243862f9",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_driver
+        commit = "7ea588b00d990e82a33545a3062296f5b7d5285a",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_driver
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,7 +21,7 @@ def vaticle_bazel_distribution():
     git_repository(
         name = "vaticle_bazel_distribution",
         remote = "https://github.com/vaticle/bazel-distribution",
-        commit = "600a741e7a6c4d58c5ba9c4fcdde43f732cd73b1",
+        commit = "ebb4a9b342ec442c427705ec6a7919cce4c35c6e",
     )
 
 def vaticle_dependencies():

--- a/framework/editor/BUILD
+++ b/framework/editor/BUILD
@@ -39,7 +39,7 @@ kt_jvm_library(
         "//framework/material:material",
 
         # External Vaticle Dependencies
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
 
         # External Maven Dependencies
         "@maven//:io_github_microutils_kotlin_logging_jvm",

--- a/framework/editor/common/BUILD
+++ b/framework/editor/common/BUILD
@@ -29,7 +29,7 @@ kt_jvm_library(
     plugins = ["@vaticle_dependencies//builder/compose:compiler_plugin"],
     deps = [
         # External Vaticle Dependencies
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
 
         # External Maven Dependencies
         "@maven//:org_jetbrains_compose_ui_ui_text_desktop",

--- a/framework/editor/highlighter/common/BUILD
+++ b/framework/editor/highlighter/common/BUILD
@@ -28,7 +28,7 @@ kt_jvm_library(
         "//framework/common:common",
 
         # External Vaticle Dependencies
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
 
         # External Maven Dependencies
         "@maven//:io_github_microutils_kotlin_logging_jvm",

--- a/framework/editor/highlighter/typeql/BUILD
+++ b/framework/editor/highlighter/typeql/BUILD
@@ -28,7 +28,7 @@ kt_jvm_library(
         "//framework/editor/highlighter/common:common",
 
         # External Vaticle Dependencies
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
         "@vaticle_typeql//grammar/java:typeql-grammar",
         "@vaticle_typeql//java:typeql-lang",
 

--- a/framework/graph/BUILD
+++ b/framework/graph/BUILD
@@ -36,7 +36,7 @@ kt_jvm_library(
 
         # External Vaticle Dependencies
         "@vaticle_force_graph//:force_graph",
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
         "@vaticle_typedb_driver//java/api:api",
         "@vaticle_typedb_driver//java/common:common",
         "@vaticle_typeql//java:typeql-lang",

--- a/framework/material/BUILD
+++ b/framework/material/BUILD
@@ -39,7 +39,7 @@ kt_jvm_library(
         # External Vaticle Dependencies
         "@vaticle_typedb_driver//java/api:api",
         "@vaticle_typedb_driver//java/common:common",
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
 
         # External Maven Dependencies
         "@maven//:org_jetbrains_compose_animation_animation_core_desktop",

--- a/framework/output/BUILD
+++ b/framework/output/BUILD
@@ -39,7 +39,7 @@ kt_jvm_library(
         "//framework/material:material",
 
         # External Vaticle Dependencies
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
         "@vaticle_typedb_driver//java/api:api",
         "@vaticle_typedb_driver//java/common:common",
         "@vaticle_typeql//java/common:common",

--- a/module/preference/BUILD
+++ b/module/preference/BUILD
@@ -37,7 +37,7 @@ kt_jvm_library(
         "//framework/common:common",
         "//framework/material:material",
 
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
 
         # External Maven Dependencies
         "@maven//:io_github_microutils_kotlin_logging_jvm",

--- a/module/project/BUILD
+++ b/module/project/BUILD
@@ -38,7 +38,6 @@ kt_jvm_library(
         "//framework/output:output",
 
         # External Vaticle Dependencies
-#        "@vaticle_typeql//common/java:common",
 
         # External Maven Dependencies
         "@maven//:io_github_microutils_kotlin_logging_jvm",

--- a/module/project/BUILD
+++ b/module/project/BUILD
@@ -38,7 +38,7 @@ kt_jvm_library(
         "//framework/output:output",
 
         # External Vaticle Dependencies
-#        "@vaticle_typedb_common//:common",
+#        "@vaticle_typeql//common/java:common",
 
         # External Maven Dependencies
         "@maven//:io_github_microutils_kotlin_logging_jvm",

--- a/module/role/BUILD
+++ b/module/role/BUILD
@@ -33,7 +33,7 @@ kt_jvm_library(
         "//framework/material:material",
 
         # External Vaticle Dependencies
-#        "@vaticle_typedb_common//:common",
+#        "@vaticle_typeql//common/java:common",
 
         # External Maven Dependencies
         "@maven//:io_github_microutils_kotlin_logging_jvm",

--- a/module/role/BUILD
+++ b/module/role/BUILD
@@ -33,7 +33,6 @@ kt_jvm_library(
         "//framework/material:material",
 
         # External Vaticle Dependencies
-#        "@vaticle_typeql//common/java:common",
 
         # External Maven Dependencies
         "@maven//:io_github_microutils_kotlin_logging_jvm",

--- a/module/rule/BUILD
+++ b/module/rule/BUILD
@@ -33,7 +33,7 @@ kt_jvm_library(
         "//framework/material:material",
 
         # External Vaticle Dependencies
-#        "@vaticle_typedb_common//:common",
+#        "@vaticle_typeql//common/java:common",
 
         # External Maven Dependencies
         "@maven//:io_github_microutils_kotlin_logging_jvm",

--- a/module/rule/BUILD
+++ b/module/rule/BUILD
@@ -33,7 +33,6 @@ kt_jvm_library(
         "//framework/material:material",
 
         # External Vaticle Dependencies
-#        "@vaticle_typeql//common/java:common",
 
         # External Maven Dependencies
         "@maven//:io_github_microutils_kotlin_logging_jvm",

--- a/module/type/BUILD
+++ b/module/type/BUILD
@@ -39,7 +39,7 @@ kt_jvm_library(
 
         # External Vaticle Dependencies
         "@vaticle_typedb_driver//java/api:api",
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
 
         # External Maven Dependencies
         "@maven//:org_jetbrains_compose_foundation_foundation_desktop",

--- a/module/user/BUILD
+++ b/module/user/BUILD
@@ -36,7 +36,7 @@ kt_jvm_library(
         "//framework/material",
 
         # External Vaticle Dependencies
-        #        "@vaticle_typedb_common//:common",
+        #        "@vaticle_typeql//common/java:common",
 
         # External Maven Dependencies
         "@maven//:io_github_microutils_kotlin_logging_jvm",

--- a/module/user/BUILD
+++ b/module/user/BUILD
@@ -36,7 +36,6 @@ kt_jvm_library(
         "//framework/material",
 
         # External Vaticle Dependencies
-        #        "@vaticle_typeql//common/java:common",
 
         # External Maven Dependencies
         "@maven//:io_github_microutils_kotlin_logging_jvm",

--- a/service/common/BUILD
+++ b/service/common/BUILD
@@ -31,7 +31,7 @@ kt_jvm_library(
     srcs = glob(["*.kt", "*/*.kt"]),
     deps = [
         # External Vaticle Dependencies
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
 
         # External Maven Dependencies
         "@maven//:ch_qos_logback_logback_classic",

--- a/service/connection/BUILD
+++ b/service/connection/BUILD
@@ -38,7 +38,7 @@ kt_jvm_library(
         "@vaticle_typedb_driver//java/common:common",
         "@vaticle_typedb_driver//java/concept:concept", #TODO: remove this after debugging
         "@vaticle_typedb_driver//java/connection:connection", #TODO: remove this after debugging
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
         "@vaticle_typeql//java/query:query",
         "@vaticle_typeql//java/pattern:pattern",
         "@vaticle_typeql//java:typeql-lang",

--- a/service/project/BUILD
+++ b/service/project/BUILD
@@ -35,7 +35,7 @@ kt_jvm_library(
         "//service/page:page",
 
         # External Vaticle Dependencies
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
 
         # External Maven Dependencies
         "@maven//:io_github_microutils_kotlin_logging_jvm",

--- a/service/schema/BUILD
+++ b/service/schema/BUILD
@@ -38,7 +38,7 @@ kt_jvm_library(
         # External Vaticle Dependencies
         "@vaticle_typedb_driver//java/api",
         "@vaticle_typedb_driver//java/common",
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
         "@vaticle_typeql//java/common",
         "@vaticle_typeql//java:typeql-lang",
         "@vaticle_typeql//java/builder:builder",

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -149,7 +149,7 @@ typedb_kt_test(
 
         # External Vaticle Dependencies
         "@vaticle_typedb_driver//java/api:api",
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
 
         # External Maven Dependencies
         "@maven//:org_jetbrains_compose_runtime_runtime_desktop",

--- a/test/integration/common/BUILD
+++ b/test/integration/common/BUILD
@@ -47,7 +47,7 @@ kt_jvm_library(
         # External Vaticle Dependencies
         "@vaticle_typedb_driver//java/api:api",
         "@vaticle_typedb_driver//java:driver-java",
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
         "@vaticle_typeql//java:typeql-lang",
         "@vaticle_typeql//java/common:common",
         "@vaticle_typeql//java/query:query",


### PR DESCRIPTION
## Usage and product changes

We no longer upload build artifacts to the github releases page. Instead, the artifacts are available from our public cloudsmith repository, linked in the release notes.

## Implementation

- update ghr to 0.16.2, as 0.12.1 does not support github releases without artifacts