### PR TITLE
Fix syntax highlighting for quoted strings

### DIFF
--- a/framework/editor/highlighter/typeql/typeql_scopes.yml
+++ b/framework/editor/highlighter/typeql/typeql_scopes.yml
@@ -95,7 +95,7 @@
 "TRUE": constant.language
 "FALSE": constant.language
 
-"STRING_": string
+"QUOTED_STRING": string
 "LONG_": constant.numeric
 "DOUBLE_": constant.numeric
 "DATE_": constant


### PR DESCRIPTION
## Usage and product changes
We fix the highlighting for string literals to make it yellow as it used to be. The highlighting had not been correct due to a bug introduced in TypeDB Studio 2.25.0. 

Before:
![image](https://github.com/vaticle/typedb-studio/assets/22564079/f4a9165b-93c7-4115-8646-5f9352e232f0)

After:
![image](https://github.com/vaticle/typedb-studio/assets/22564079/24d88b06-4ff5-4f44-9feb-f30131b9116e)

## Implementation
The issue comes from [this PR](https://github.com/vaticle/typeql/commit/8bf4c1cd4a4609b4c45e21853f67db67ce73724b). 
We introduced `QUOTED_STRING` in the .g4 file as a new string literal, but we didn't fix the reference to the old `STRING_` in the studio. Now we did.