### PR TITLE
Update choco dependencies to use python39 package

### DIFF
--- a/.circleci/windows/dependencies.config
+++ b/.circleci/windows/dependencies.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
     <package id="bazelisk" version="1.17.0"/>
-    <package id="python" version="3.7.4"/>
+    <package id="python39" version="3.9.13"/>
     <package id="openjdk11" version="11.0.9.11"/>
 </packages>

--- a/.circleci/windows/prepare.bat
+++ b/.circleci/windows/prepare.bat
@@ -26,12 +26,12 @@ REM install dependencies needed for build
 choco install .circleci\windows\dependencies.config  --limit-output --yes --no-progress
 
 REM create a symlink python3.exe and make it available in %PATH%
-mklink C:\Python37\python3.exe C:\Python37\python.exe
+mklink C:\Python39\python3.exe C:\Python39\python.exe
 SET PATH=%PATH%;C:\Python39
 
 REM install runtime dependency for the build
-C:\Python37\python.exe -m pip install wheel
+C:\Python39\python.exe -m pip install wheel
 
 REM permanently set variables for Bazel build
 SETX BAZEL_SH "C:\Program Files\Git\usr\bin\bash.exe"
-SETX BAZEL_PYTHON C:\Python37\python.exe
+SETX BAZEL_PYTHON C:\Python39\python.exe


### PR DESCRIPTION
## Usage and product changes

Choco is `unable to resolve dependency 'python3 (= 3.7.4)'.` We upgrade to 3.9.