### PR TITLE
Cloud address translation

### DIFF
--- a/module/user/UpdateDefaultPasswordDialog.kt
+++ b/module/user/UpdateDefaultPasswordDialog.kt
@@ -32,8 +32,17 @@ object UpdateDefaultPasswordDialog {
         var newPassword: String by mutableStateOf("")
         var repeatPassword: String by mutableStateOf("")
 
-        override fun cancel() = Service.driver.updateDefaultPasswordDialog.cancel()
-        override fun submit() = Service.driver.updateDefaultPasswordDialog.submit(oldPassword, newPassword)
+        override fun cancel() {
+            Service.driver.updateDefaultPasswordDialog.cancel()
+            oldPassword = ""
+            newPassword = ""
+        }
+        override fun submit() {
+            assert(isValid())
+            Service.driver.updateDefaultPasswordDialog.submit(oldPassword, newPassword)
+            oldPassword = ""
+            newPassword = ""
+        }
         override fun isValid() = oldPassword.isNotEmpty() && newPassword.isNotEmpty()
                     && oldPassword != newPassword && repeatPassword == newPassword
     }

--- a/service/common/DataService.kt
+++ b/service/common/DataService.kt
@@ -61,6 +61,8 @@ class DataService {
         private val CONNECTION_SERVER = "connection.server"
         private val CONNECTION_CORE_ADDRESS = "connection.core_address"
         private val CONNECTION_CLOUD_ADDRESSES = "connection.cloud_addresses"
+        private val CONNECTION_CLOUD_ADDRESS_TRANSLATION = "connection.cloud_address_translation"
+        private val CONNECTION_USE_CLOUD_ADDRESS_TRANSLATION = "connection.use_cloud_address_translation"
         private val CONNECTION_USERNAME = "connection.username"
         private val CONNECTION_TLS_ENABLED = "connection.tls_enabled"
         private val CONNECTION_CA_CERTIFICATE = "connection.ca_certificate"
@@ -71,10 +73,18 @@ class DataService {
         var coreAddress: String?
             get() = properties?.getProperty(CONNECTION_CORE_ADDRESS)
             set(value) = value?.let { setProperty(CONNECTION_CORE_ADDRESS, it) } ?: Unit
-        var cloudAddresses: MutableList<String>?
+        var cloudAddresses: List<String>?
             get() = properties?.getProperty(CONNECTION_CLOUD_ADDRESSES)
-                ?.split(",")?.filter { it.isNotBlank() }?.toMutableList()
+                ?.split(",")?.filter { it.isNotBlank() }
             set(value) = value?.let { setProperty(CONNECTION_CLOUD_ADDRESSES, it.joinToString(",")) } ?: Unit
+        var cloudAddressTranslation: List<Pair<String, String>>?
+            get() = properties?.getProperty(CONNECTION_CLOUD_ADDRESS_TRANSLATION)
+                ?.split(",")?.filter { it.contains("=") }?.map { it.split("=", limit = 2) }?.map{ it[0] to it[1] }
+            set(value) = value
+                ?.let { setProperty(CONNECTION_CLOUD_ADDRESS_TRANSLATION, it.map { pair -> "${pair.first}=${pair.second}" } .joinToString(",")) } ?: Unit
+        var useCloudAddressTranslation: Boolean?
+            get() = properties?.getProperty(CONNECTION_USE_CLOUD_ADDRESS_TRANSLATION)?.toBooleanStrictOrNull()
+            set(value) = value?.let { setProperty(CONNECTION_USE_CLOUD_ADDRESS_TRANSLATION, it.toString()) } ?: Unit
         var username: String?
             get() = properties?.getProperty(CONNECTION_USERNAME)
             set(value) = value?.let { setProperty(CONNECTION_USERNAME, it) } ?: Unit

--- a/service/common/util/Label.kt
+++ b/service/common/util/Label.kt
@@ -229,6 +229,7 @@ object Label {
     const val TRANSACTION_STATUS = "Transaction Status"
     const val TRANSACTION_TIMEOUT_MINS = "Transaction Timeout (mins)"
     const val TRANSACTION_TYPE = "Transaction Type"
+    const val TRANSLATE_ADDRESSES = "Translate addresses"
     const val TYPE = "Type"
     const val TYPEDB_STUDIO = "TypeDB Studio"
     const val TYPEDB_STUDIO_APPLICATION_ERROR = "TypeDB Studio Application Error"


### PR DESCRIPTION
## Usage and product changes

We introduce a way to provide address translation when attempting to connect to cloud servers (cf. https://github.com/vaticle/typedb-driver/pull/624). This is useful when the route from the user to the servers differs from the route the servers are configured with (e.g. connection to public-facing servers from an internal network).

Note: we currently require that the user provides translation for the addresses of _all_ nodes in the Cloud deployment.

<img width="532" src="https://github.com/vaticle/typedb-studio/assets/18616863/74859fbd-de4f-4844-b1e6-f3507dc364b7">

