### PR TITLE
Update dependencies to typedb's development mode for integration tests and fix build

### DIFF
--- a/dependencies/maven/artifacts.snapshot
+++ b/dependencies/maven/artifacts.snapshot
@@ -21,9 +21,9 @@
 @maven//:com_google_protobuf_protobuf_java_3_21_1
 @maven//:com_google_truth_truth_1_0_1
 @maven//:com_googlecode_java_diff_utils_diffutils_1_3_0
-@maven//:com_vaticle_typedb_typedb_cloud_runner_2_28_3_rc0
+@maven//:com_vaticle_typedb_typedb_cloud_runner_2_28_3
 @maven//:com_vaticle_typedb_typedb_common_2_28_1
-@maven//:com_vaticle_typedb_typedb_runner_2_28_3_rc0
+@maven//:com_vaticle_typedb_typedb_runner_2_28_3
 @maven//:com_vdurmont_semver4j_3_1_0
 @maven//:commons_codec_commons_codec_1_13
 @maven//:commons_io_commons_io_2_3

--- a/dependencies/maven/artifacts.snapshot
+++ b/dependencies/maven/artifacts.snapshot
@@ -21,8 +21,9 @@
 @maven//:com_google_protobuf_protobuf_java_3_21_1
 @maven//:com_google_truth_truth_1_0_1
 @maven//:com_googlecode_java_diff_utils_diffutils_1_3_0
-@maven//:com_vaticle_typedb_typedb_cloud_runner_0_0_0_78f5c1c83be5f0c8982b86ae4d15dd0b2f377905
-@maven//:com_vaticle_typedb_typedb_runner_0_0_0_e182b2dfcaf5f4cf7e7ce3dbb46edad3dccc48e0
+@maven//:com_vaticle_typedb_typedb_cloud_runner_2_28_3_rc0
+@maven//:com_vaticle_typedb_typedb_common_2_28_1
+@maven//:com_vaticle_typedb_typedb_runner_2_28_3_rc0
 @maven//:com_vdurmont_semver4j_3_1_0
 @maven//:commons_codec_commons_codec_1_13
 @maven//:commons_io_commons_io_2_3
@@ -152,5 +153,5 @@
 @maven//:org_slf4j_log4j_over_slf4j_2_0_0
 @maven//:org_slf4j_slf4j_api_2_0_0
 @maven//:org_slf4j_slf4j_simple_2_0_0
-@maven//:org_yaml_snakeyaml_1_25
+@maven//:org_yaml_snakeyaml_2_2
 @maven//:org_zeroturnaround_zt_exec_1_10

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -12,10 +12,10 @@ def vaticle_typedb_artifact():
         artifact_name = "typedb-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact"]["release"]["download"],
         commit_source = deployment["artifact"]["snapshot"]["download"],
-        tag = "2.28.3-rc0",
+        tag = "2.28.3",
     )
 
 maven_artifacts = {
-    'com.vaticle.typedb:typedb-runner': '2.28.3-rc0',
-    'com.vaticle.typedb:typedb-cloud-runner': '2.28.3-rc0',
+    'com.vaticle.typedb:typedb-runner': '2.28.3',
+    'com.vaticle.typedb:typedb-cloud-runner': '2.28.3',
 }

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -12,10 +12,10 @@ def vaticle_typedb_artifact():
         artifact_name = "typedb-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact"]["release"]["download"],
         commit_source = deployment["artifact"]["snapshot"]["download"],
-        tag = "2.26.3",
+        tag = "2.28.3-rc0",
     )
 
 maven_artifacts = {
-    'com.vaticle.typedb:typedb-runner': '0.0.0-e182b2dfcaf5f4cf7e7ce3dbb46edad3dccc48e0',
-    'com.vaticle.typedb:typedb-cloud-runner': '0.0.0-78f5c1c83be5f0c8982b86ae4d15dd0b2f377905',
+    'com.vaticle.typedb:typedb-runner': '2.28.3-rc0',
+    'com.vaticle.typedb:typedb-cloud-runner': '2.28.3-rc0',
 }

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -15,7 +15,7 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "085580d6900c0a30d015a62d4f8c2ae6ca85a505", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "8ed4fd2b3bfcfbeb572322364e4b3fb8b77064e0", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_force_graph():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -15,7 +15,7 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "8ed4fd2b3bfcfbeb572322364e4b3fb8b77064e0", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "294ef724c3853c9851e1e0c6bc04e0470c724e10", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_force_graph():


### PR DESCRIPTION
## Usage and product changes
We update `typedb` dependencies to run integration tests in the newly introduced `development-mode` that disables external reporting for CI and other test builds. We also fix `maven` artifacts after multiple `sync-dependencies` to fix the CI builds.
