### PR TITLE
In text editor, fix behaviour of Home and End keys

### DIFF
--- a/framework/common/KeyMapper.kt
+++ b/framework/common/KeyMapper.kt
@@ -46,8 +46,8 @@ interface KeyMapper {
         MOVE_LINE_DOWN,
         MOVE_PAGE_UP,
         MOVE_PAGE_DOWN,
-        MOVE_HOME,
-        MOVE_END,
+        MOVE_CONTENT_START,
+        MOVE_CONTENT_END,
 
         SELECT_NONE,
         SELECT_ALL,
@@ -65,8 +65,8 @@ interface KeyMapper {
         SELECT_LINE_DOWN,
         SELECT_PAGE_UP,
         SELECT_PAGE_DOWN,
-        SELECT_HOME,
-        SELECT_END,
+        SELECT_CONTENT_START,
+        SELECT_CONTENT_END,
 
         DELETE_CHAR_PREV,
         DELETE_CHAR_NEXT,
@@ -170,8 +170,8 @@ interface KeyMapper {
                     Keys.DirectionRight -> Command.SELECT_LINE_RIGHT
                     Keys.DirectionUp -> Command.REORDER_LINES_UP
                     Keys.DirectionDown -> Command.REORDER_LINES_DOWN
-                    Keys.MoveHome -> Command.SELECT_HOME
-                    Keys.MoveEnd -> Command.SELECT_END
+                    Keys.MoveHome -> Command.SELECT_CONTENT_START
+                    Keys.MoveEnd -> Command.SELECT_CONTENT_END
                     else -> null
                 }
                 shortcutModifier(event) -> when (event.key) {
@@ -190,8 +190,8 @@ interface KeyMapper {
                     Keys.Equals -> Command.TEXT_SIZE_INCREASE
                     Keys.Minus -> Command.TEXT_SIZE_DECREASE
                     Keys.Zero -> Command.TEXT_SIZE_RESET
-                    Keys.MoveHome -> Command.MOVE_HOME
-                    Keys.MoveEnd -> Command.MOVE_END
+                    Keys.MoveHome -> Command.MOVE_CONTENT_START
+                    Keys.MoveEnd -> Command.MOVE_CONTENT_END
                     else -> null
                 }
                 event.isCtrlPressed && event.isShiftPressed -> when (event.key) {
@@ -292,8 +292,8 @@ interface KeyMapper {
                 event.isMetaPressed -> when (event.key) {
                     Keys.DirectionLeft -> Command.MOVE_LINE_LEFT
                     Keys.DirectionRight -> Command.MOVE_LINE_RIGHT
-                    Keys.DirectionUp -> Command.MOVE_HOME
-                    Keys.DirectionDown -> Command.MOVE_END
+                    Keys.DirectionUp -> Command.MOVE_CONTENT_START
+                    Keys.DirectionDown -> Command.MOVE_CONTENT_END
                     Keys.Backspace -> Command.DELETE_LINE_START
                     Keys.Q -> Command.QUIT
                     Keys.R -> Command.REPLACE

--- a/framework/common/KeyMapper.kt
+++ b/framework/common/KeyMapper.kt
@@ -170,6 +170,8 @@ interface KeyMapper {
                     Keys.DirectionRight -> Command.SELECT_LINE_RIGHT
                     Keys.DirectionUp -> Command.REORDER_LINES_UP
                     Keys.DirectionDown -> Command.REORDER_LINES_DOWN
+                    Keys.MoveHome -> Command.SELECT_HOME
+                    Keys.MoveEnd -> Command.SELECT_END
                     else -> null
                 }
                 shortcutModifier(event) -> when (event.key) {
@@ -188,6 +190,8 @@ interface KeyMapper {
                     Keys.Equals -> Command.TEXT_SIZE_INCREASE
                     Keys.Minus -> Command.TEXT_SIZE_DECREASE
                     Keys.Zero -> Command.TEXT_SIZE_RESET
+                    Keys.MoveHome -> Command.MOVE_HOME
+                    Keys.MoveEnd -> Command.MOVE_END
                     else -> null
                 }
                 event.isCtrlPressed && event.isShiftPressed -> when (event.key) {
@@ -212,8 +216,8 @@ interface KeyMapper {
                     Keys.DirectionDown -> Command.SELECT_LINE_DOWN
                     Keys.PageUp -> Command.SELECT_PAGE_UP
                     Keys.PageDown -> Command.SELECT_PAGE_DOWN
-                    Keys.MoveHome -> Command.SELECT_HOME
-                    Keys.MoveEnd -> Command.SELECT_END
+                    Keys.MoveHome -> Command.SELECT_LINE_START
+                    Keys.MoveEnd -> Command.SELECT_LINE_END
                     Keys.Insert -> Command.PASTE
                     Keys.Tab -> Command.TAB_SHIFT
                     Keys.Enter, Keys.EnterNumPad -> Command.ENTER_SHIFT
@@ -226,8 +230,8 @@ interface KeyMapper {
                     Keys.DirectionDown -> Command.MOVE_LINE_DOWN
                     Keys.PageUp -> Command.MOVE_PAGE_UP
                     Keys.PageDown -> Command.MOVE_PAGE_DOWN
-                    Keys.MoveHome -> Command.MOVE_HOME
-                    Keys.MoveEnd -> Command.MOVE_END
+                    Keys.MoveHome -> Command.MOVE_LINE_START
+                    Keys.MoveEnd -> Command.MOVE_LINE_END
                     Keys.Enter, Keys.EnterNumPad -> Command.ENTER
                     Keys.Backspace -> Command.DELETE_CHAR_PREV
                     Keys.Delete -> Command.DELETE_CHAR_NEXT

--- a/framework/editor/EventHandler.kt
+++ b/framework/editor/EventHandler.kt
@@ -32,8 +32,8 @@ import com.vaticle.typedb.studio.framework.common.KeyMapper.Command.ENTER_SHIFT
 import com.vaticle.typedb.studio.framework.common.KeyMapper.Command.MOD_ENTER
 import com.vaticle.typedb.studio.framework.common.KeyMapper.Command.MOVE_CHAR_LEFT
 import com.vaticle.typedb.studio.framework.common.KeyMapper.Command.MOVE_CHAR_RIGHT
-import com.vaticle.typedb.studio.framework.common.KeyMapper.Command.MOVE_END
-import com.vaticle.typedb.studio.framework.common.KeyMapper.Command.MOVE_HOME
+import com.vaticle.typedb.studio.framework.common.KeyMapper.Command.MOVE_CONTENT_END
+import com.vaticle.typedb.studio.framework.common.KeyMapper.Command.MOVE_CONTENT_START
 import com.vaticle.typedb.studio.framework.common.KeyMapper.Command.MOVE_LINE_DOWN
 import com.vaticle.typedb.studio.framework.common.KeyMapper.Command.MOVE_LINE_END
 import com.vaticle.typedb.studio.framework.common.KeyMapper.Command.MOVE_LINE_LEFT
@@ -53,8 +53,8 @@ import com.vaticle.typedb.studio.framework.common.KeyMapper.Command.REORDER_LINE
 import com.vaticle.typedb.studio.framework.common.KeyMapper.Command.SELECT_ALL
 import com.vaticle.typedb.studio.framework.common.KeyMapper.Command.SELECT_CHAR_LEFT
 import com.vaticle.typedb.studio.framework.common.KeyMapper.Command.SELECT_CHAR_RIGHT
-import com.vaticle.typedb.studio.framework.common.KeyMapper.Command.SELECT_END
-import com.vaticle.typedb.studio.framework.common.KeyMapper.Command.SELECT_HOME
+import com.vaticle.typedb.studio.framework.common.KeyMapper.Command.SELECT_CONTENT_END
+import com.vaticle.typedb.studio.framework.common.KeyMapper.Command.SELECT_CONTENT_START
 import com.vaticle.typedb.studio.framework.common.KeyMapper.Command.SELECT_LINE_DOWN
 import com.vaticle.typedb.studio.framework.common.KeyMapper.Command.SELECT_LINE_END
 import com.vaticle.typedb.studio.framework.common.KeyMapper.Command.SELECT_LINE_LEFT
@@ -123,8 +123,8 @@ internal class EventHandler constructor(
             MOVE_LINE_DOWN -> target.moveCursorDownByLine()
             MOVE_PAGE_UP -> target.moveCursorUpByPage()
             MOVE_PAGE_DOWN -> target.moveCursorDownByPage()
-            MOVE_HOME -> target.moveCursorToStartOfContent()
-            MOVE_END -> target.moveCursorToEndOfContent()
+            MOVE_CONTENT_START -> target.moveCursorToStartOfContent()
+            MOVE_CONTENT_END -> target.moveCursorToEndOfContent()
             SELECT_CHAR_LEFT -> target.moveCursorPrevByChar(true) // because we only display left to right
             SELECT_CHAR_RIGHT -> target.moveCursorNextByChar(true) // because we only display left to right
             SELECT_WORD_LEFT -> target.moveCursorPrevByWord(true) // because we only display left to right
@@ -139,8 +139,8 @@ internal class EventHandler constructor(
             SELECT_LINE_DOWN -> target.moveCursorDownByLine(true)
             SELECT_PAGE_UP -> target.moveCursorUpByPage(true)
             SELECT_PAGE_DOWN -> target.moveCursorDownByPage(true)
-            SELECT_HOME -> target.moveCursorToStartOfContent(true)
-            SELECT_END -> target.moveCursorToEndOfContent(true)
+            SELECT_CONTENT_START -> target.moveCursorToStartOfContent(true)
+            SELECT_CONTENT_END -> target.moveCursorToEndOfContent(true)
             SELECT_ALL -> target.selectAll()
             SELECT_NONE -> target.selectNone()
             REORDER_LINES_UP -> processor.reorderLinesUp()


### PR DESCRIPTION
## Usage and product changes

The behaviour of Home and End keys are now in line with most other text editors, moving to the start/end of the line (rather than the file) unless Ctrl (Cmd on MacOS) is additionally pressed.

## Implementation

We had some confusing terminology in the `Command` class - `MOVE_HOME` and `MOVE_END` intuitively sounded like they should correspond to a keyboard's Home and End keys, but this resulted in incorrect behaviour. We've renamed them to `MOVE_CONTENT_START` and `MOVE_CONTENT_END`, and these are now correctly only triggered by Ctrl+Home and Ctrl+End respectively. Home and End take you to the start/end of a line. If Shift is additionally pressed in any case, trigger selection.